### PR TITLE
feat: internal/jobspec + internal/k8s — build and create suspended Job

### DIFF
--- a/internal/jobspec/build.go
+++ b/internal/jobspec/build.go
@@ -1,0 +1,97 @@
+package jobspec
+
+import (
+	"fmt"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sebastiaankok/agents/internal/github"
+)
+
+const (
+	DefaultJobImage      = "ghcr.io/sebastiaankok/agents/opencode-runner:latest"
+	DefaultConfigMapName = "opencode-config"
+	credentialsSecret    = "agentctl-credentials"
+	opencodeConfigDir    = "/root/.config/opencode"
+	jobTTL               = int32(604800)
+)
+
+// Config controls Job creation parameters.
+type Config struct {
+	JobImage           string
+	ConfigMapName      string
+	ServiceAccountName string
+	Namespace          string
+}
+
+// Build returns a suspended Kubernetes Job spec for the given issue.
+func Build(issue github.Issue, repoURL, defaultBranch string, cfg Config) *batchv1.Job {
+	image := cfg.JobImage
+	if image == "" {
+		image = DefaultJobImage
+	}
+	cmName := cfg.ConfigMapName
+	if cmName == "" {
+		cmName = DefaultConfigMapName
+	}
+
+	suspend := true
+	ttl := jobTTL
+
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("agent-issue-%d", issue.Number),
+			Namespace: cfg.Namespace,
+			Labels:    map[string]string{"issue-number": fmt.Sprintf("%d", issue.Number)},
+		},
+		Spec: batchv1.JobSpec{
+			Suspend:                 &suspend,
+			TTLSecondsAfterFinished: &ttl,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					ServiceAccountName: cfg.ServiceAccountName,
+					RestartPolicy:      corev1.RestartPolicyNever,
+					Containers: []corev1.Container{
+						{
+							Name:  "runner",
+							Image: image,
+							Env: []corev1.EnvVar{
+								{Name: "ISSUE_NUMBER", Value: fmt.Sprintf("%d", issue.Number)},
+								{
+									Name: "GITHUB_TOKEN",
+									ValueFrom: &corev1.EnvVarSource{
+										SecretKeyRef: &corev1.SecretKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{Name: credentialsSecret},
+											Key:                  "GITHUB_TOKEN",
+										},
+									},
+								},
+								{Name: "REPO_URL", Value: repoURL},
+								{Name: "DEFAULT_BRANCH", Value: defaultBranch},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "opencode-config",
+									MountPath: opencodeConfigDir,
+									ReadOnly:  true,
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "opencode-config",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: cmName},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/jobspec/build_test.go
+++ b/internal/jobspec/build_test.go
@@ -1,0 +1,158 @@
+package jobspec_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/sebastiaankok/agents/internal/github"
+	"github.com/sebastiaankok/agents/internal/jobspec"
+)
+
+func issue(n int) github.Issue {
+	return github.Issue{Number: n, Title: "fix something", Body: "body"}
+}
+
+func cfg() jobspec.Config {
+	return jobspec.Config{
+		Namespace: "agent-runners",
+	}
+}
+
+func TestBuild_Name(t *testing.T) {
+	job := jobspec.Build(issue(42), "https://github.com/org/repo", "main", cfg())
+	if job == nil {
+		t.Fatal("Build returned nil")
+	}
+	want := "agent-issue-42"
+	if job.Name != want {
+		t.Errorf("Name = %q, want %q", job.Name, want)
+	}
+}
+
+func TestBuild_Suspend(t *testing.T) {
+	job := jobspec.Build(issue(1), "https://github.com/org/repo", "main", cfg())
+	if job.Spec.Suspend == nil || !*job.Spec.Suspend {
+		t.Error("spec.suspend must be true")
+	}
+}
+
+func TestBuild_TTL(t *testing.T) {
+	job := jobspec.Build(issue(1), "https://github.com/org/repo", "main", cfg())
+	if job.Spec.TTLSecondsAfterFinished == nil || *job.Spec.TTLSecondsAfterFinished != 604800 {
+		t.Errorf("TTLSecondsAfterFinished = %v, want 604800", job.Spec.TTLSecondsAfterFinished)
+	}
+}
+
+func TestBuild_IssueLabel(t *testing.T) {
+	job := jobspec.Build(issue(99), "https://github.com/org/repo", "main", cfg())
+	got := job.Labels["issue-number"]
+	if got != "99" {
+		t.Errorf("label issue-number = %q, want %q", got, "99")
+	}
+}
+
+func TestBuild_EnvVars(t *testing.T) {
+	job := jobspec.Build(issue(7), "https://github.com/org/repo", "develop", cfg())
+	envMap := make(map[string]string)
+	for _, e := range job.Spec.Template.Spec.Containers[0].Env {
+		if e.Value != "" {
+			envMap[e.Name] = e.Value
+		}
+	}
+	cases := map[string]string{
+		"ISSUE_NUMBER":   "7",
+		"REPO_URL":       "https://github.com/org/repo",
+		"DEFAULT_BRANCH": "develop",
+	}
+	for k, v := range cases {
+		if envMap[k] != v {
+			t.Errorf("env %s = %q, want %q", k, envMap[k], v)
+		}
+	}
+}
+
+func TestBuild_GitHubTokenFromSecret(t *testing.T) {
+	job := jobspec.Build(issue(1), "https://github.com/org/repo", "main", cfg())
+	var tokenEnv *struct{ name, secretName, key string }
+	for _, e := range job.Spec.Template.Spec.Containers[0].Env {
+		if e.Name == "GITHUB_TOKEN" && e.ValueFrom != nil && e.ValueFrom.SecretKeyRef != nil {
+			tokenEnv = &struct{ name, secretName, key string }{
+				name:       e.Name,
+				secretName: e.ValueFrom.SecretKeyRef.Name,
+				key:        e.ValueFrom.SecretKeyRef.Key,
+			}
+		}
+	}
+	if tokenEnv == nil {
+		t.Fatal("GITHUB_TOKEN env var with SecretKeyRef not found")
+	}
+	if tokenEnv.secretName != "agentctl-credentials" {
+		t.Errorf("secret name = %q, want %q", tokenEnv.secretName, "agentctl-credentials")
+	}
+	if tokenEnv.key != "GITHUB_TOKEN" {
+		t.Errorf("secret key = %q, want %q", tokenEnv.key, "GITHUB_TOKEN")
+	}
+}
+
+func TestBuild_ConfigMapMount(t *testing.T) {
+	job := jobspec.Build(issue(1), "https://github.com/org/repo", "main", cfg())
+	containers := job.Spec.Template.Spec.Containers
+	if len(containers) == 0 {
+		t.Fatal("no containers")
+	}
+	var found bool
+	for _, vm := range containers[0].VolumeMounts {
+		if vm.MountPath == "/root/.config/opencode" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("no volume mount at /root/.config/opencode")
+	}
+	for _, v := range job.Spec.Template.Spec.Volumes {
+		if v.ConfigMap != nil && v.ConfigMap.Name == "opencode-config" {
+			return
+		}
+	}
+	t.Error("no volume referencing opencode-config ConfigMap")
+}
+
+func TestBuild_DefaultImage(t *testing.T) {
+	job := jobspec.Build(issue(1), "https://github.com/org/repo", "main", cfg())
+	got := job.Spec.Template.Spec.Containers[0].Image
+	if got != jobspec.DefaultJobImage {
+		t.Errorf("Image = %q, want %q", got, jobspec.DefaultJobImage)
+	}
+}
+
+func TestBuild_CustomImage(t *testing.T) {
+	c := cfg()
+	c.JobImage = "my-registry/custom:v1"
+	job := jobspec.Build(issue(1), "https://github.com/org/repo", "main", c)
+	got := job.Spec.Template.Spec.Containers[0].Image
+	if got != "my-registry/custom:v1" {
+		t.Errorf("Image = %q, want %q", got, "my-registry/custom:v1")
+	}
+}
+
+func TestBuild_CustomConfigMap(t *testing.T) {
+	c := cfg()
+	c.ConfigMapName = "my-opencode-config"
+	job := jobspec.Build(issue(1), "https://github.com/org/repo", "main", c)
+	for _, v := range job.Spec.Template.Spec.Volumes {
+		if v.ConfigMap != nil && v.ConfigMap.Name == "my-opencode-config" {
+			return
+		}
+	}
+	t.Errorf("no volume referencing ConfigMap %q", "my-opencode-config")
+}
+
+func TestBuild_Namespace(t *testing.T) {
+	job := jobspec.Build(issue(5), "https://github.com/org/repo", "main", cfg())
+	if job.Namespace != "agent-runners" {
+		t.Errorf("Namespace = %q, want %q", job.Namespace, "agent-runners")
+	}
+}
+
+// keep compiler happy
+var _ = fmt.Sprintf

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -1,0 +1,78 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+
+	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// Client wraps the Kubernetes API for agent Job operations.
+type Client struct {
+	kube kubernetes.Interface
+}
+
+// NewClient returns a Client backed by the given kubernetes.Interface.
+func NewClient(kube kubernetes.Interface) *Client {
+	return &Client{kube: kube}
+}
+
+// CreateJob creates the Job in the given namespace.
+func (c *Client) CreateJob(ctx context.Context, namespace string, job *batchv1.Job) error {
+	_, err := c.kube.BatchV1().Jobs(namespace).Create(ctx, job, metav1.CreateOptions{})
+	return err
+}
+
+// ListJobs returns Jobs in namespace matching labelSelector.
+func (c *Client) ListJobs(ctx context.Context, namespace, labelSelector string) ([]batchv1.Job, error) {
+	list, err := c.kube.BatchV1().Jobs(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return list.Items, nil
+}
+
+// JobExists returns true if a Job with label issue-number=<issueNumber> exists in namespace.
+func (c *Client) JobExists(ctx context.Context, namespace string, issueNumber int) (bool, error) {
+	selector := fmt.Sprintf("issue-number=%d", issueNumber)
+	jobs, err := c.ListJobs(ctx, namespace, selector)
+	if err != nil {
+		return false, err
+	}
+	return len(jobs) > 0, nil
+}
+
+// UnsuspendJob sets spec.suspend=false on the named Job.
+func (c *Client) UnsuspendJob(ctx context.Context, namespace, name string) error {
+	job, err := c.kube.BatchV1().Jobs(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	f := false
+	job.Spec.Suspend = &f
+	_, err = c.kube.BatchV1().Jobs(namespace).Update(ctx, job, metav1.UpdateOptions{})
+	return err
+}
+
+// ValidateSecret returns an error if the named Secret does not exist in namespace.
+func (c *Client) ValidateSecret(ctx context.Context, namespace, name string) error {
+	_, err := c.kube.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		return fmt.Errorf("secret %q not found in namespace %q", name, namespace)
+	}
+	return err
+}
+
+// ValidateConfigMap returns an error if the named ConfigMap does not exist in namespace.
+func (c *Client) ValidateConfigMap(ctx context.Context, namespace, name string) error {
+	_, err := c.kube.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		return fmt.Errorf("configmap %q not found in namespace %q", name, namespace)
+	}
+	return err
+}


### PR DESCRIPTION
## Summary

- `jobspec.Build` produces a fully-specified suspended `batchv1.Job`: `spec.suspend=true`, TTL 604800s, label `issue-number=N`, env vars `ISSUE_NUMBER`/`GITHUB_TOKEN`/`REPO_URL`/`DEFAULT_BRANCH`, opencode ConfigMap mounted at `/root/.config/opencode`, configurable image with default
- `k8s.Client` adds `CreateJob`, `ListJobs`, `JobExists`, `UnsuspendJob`, `ValidateSecret`, `ValidateConfigMap`
- 11 unit tests cover all `jobspec.Build` fields via public interface only

## Test plan

- [x] `go test ./internal/jobspec/...` — 11 tests, all pass
- [x] `go build ./...` — clean build

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)