### PR TITLE
feat: implement agentctl run command

### DIFF
--- a/cmd/agentctl/main.go
+++ b/cmd/agentctl/main.go
@@ -14,6 +14,7 @@ func newRootCmd() *cobra.Command {
 			return cmd.Help()
 		},
 	}
+	root.AddCommand(newInstallCmd())
 	root.AddCommand(newRunCmd(nil))
 	return root
 }

--- a/cmd/agentctl/main_test.go
+++ b/cmd/agentctl/main_test.go
@@ -9,18 +9,43 @@ import (
 )
 
 func TestRunCommand_JobImageFlag(t *testing.T) {
-	var capturedImage string
+	var capturedCfg jobspec.Config
 	cmd := newRunCmd(func(cfg jobspec.Config) {
-		capturedImage = cfg.JobImage
+		capturedCfg = cfg
 	})
-	cmd.SetArgs([]string{"--job-image", "custom:v2"})
+	cmd.SetArgs([]string{"--job-image", "custom:v2", "--dry-run"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
 
-	if capturedImage != "custom:v2" {
-		t.Errorf("Image = %q, want %q", capturedImage, "custom:v2")
+	if capturedCfg.JobImage != "custom:v2" {
+		t.Errorf("JobImage = %q, want %q", capturedCfg.JobImage, "custom:v2")
+	}
+}
+
+func TestRunCommand_Flags(t *testing.T) {
+	var capturedCfg jobspec.Config
+	cmd := newRunCmd(func(cfg jobspec.Config) {
+		capturedCfg = cfg
+	})
+	cmd.SetArgs([]string{
+		"--job-image", "custom:v2",
+		"--issue", "42",
+		"--namespace", "test-ns",
+		"--max-parallel", "5",
+		"--dry-run",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if capturedCfg.JobImage != "custom:v2" {
+		t.Errorf("JobImage = %q, want %q", capturedCfg.JobImage, "custom:v2")
+	}
+	if capturedCfg.Namespace != "test-ns" {
+		t.Errorf("Namespace = %q, want %q", capturedCfg.Namespace, "test-ns")
 	}
 }
 

--- a/cmd/agentctl/run.go
+++ b/cmd/agentctl/run.go
@@ -1,25 +1,251 @@
 package main
 
 import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	gitinternal "github.com/sebastiaankok/agents/internal/git"
+	"github.com/sebastiaankok/agents/internal/github"
 	"github.com/sebastiaankok/agents/internal/jobspec"
+	k8sinternal "github.com/sebastiaankok/agents/internal/k8s"
 	"github.com/spf13/cobra"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 func newRunCmd(onConfig func(jobspec.Config)) *cobra.Command {
-	var cfg jobspec.Config
+	var (
+		cfg           jobspec.Config
+		flIssue       int
+		flNamespace   string
+		flMaxParallel int
+		flDryRun      bool
+	)
 
 	cmd := &cobra.Command{
 		Use:   "run",
 		Short: "Fetch ready-for-agent issues and create Kubernetes Jobs",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg.Namespace = flNamespace
 			if onConfig != nil {
 				onConfig(cfg)
 			}
+
+			if flDryRun {
+				return nil
+			}
+
+			kclient, err := newK8sClient()
+			if err != nil {
+				return err
+			}
+
+			c := k8sinternal.NewClient(kclient)
+
+			if err := validatePrereqs(cmd.Context(), c, cfg.Namespace); err != nil {
+				return err
+			}
+
+			repo, err := gitinternal.InferRepo()
+			if err != nil {
+				return fmt.Errorf("infer repo: %w", err)
+			}
+
+			defaultBranch, err := defaultBranch()
+			if err != nil {
+				return fmt.Errorf("get default branch: %w", err)
+			}
+
+			gc := github.NewClient("")
+
+			var issues []github.Issue
+			if flIssue > 0 {
+				issue, err := gc.GetIssue(cmd.Context(), repo, flIssue)
+				if err != nil {
+					return fmt.Errorf("fetch issue %d: %w", flIssue, err)
+				}
+				issues = append(issues, issue)
+			} else {
+				issues, err = gc.GetReadyIssues(cmd.Context(), repo)
+				if err != nil {
+					return fmt.Errorf("fetch ready issues: %w", err)
+				}
+			}
+
+			if len(issues) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "no ready-for-agent issues found")
+				return nil
+			}
+
+			created, skipped := createJobs(cmd.Context(), cmd.ErrOrStderr(), c, issues, repo, defaultBranch, cfg, flMaxParallel)
+
+			fmt.Fprintf(cmd.OutOrStdout(), "\ncreated %d job(s), skipped %d (already active)\n", created, skipped)
 			return nil
 		},
 	}
 
 	cmd.Flags().StringVar(&cfg.JobImage, "job-image", "", "override the default runner image")
+	cmd.Flags().IntVar(&flIssue, "issue", 0, "target a single issue by number (0 = all ready-for-agent)")
+	cmd.Flags().StringVar(&flNamespace, "namespace", "agent-runners", "target namespace")
+	cmd.Flags().IntVar(&flMaxParallel, "max-parallel", 3, "maximum concurrent jobs (stored as annotation)")
+	cmd.Flags().BoolVar(&flDryRun, "dry-run", false, "parse flags only without executing")
+	_ = cmd.Flags().MarkHidden("dry-run")
 
 	return cmd
+}
+
+func newK8sClient() (*kubernetes.Clientset, error) {
+	cfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		clientcmd.NewDefaultClientConfigLoadingRules(),
+		&clientcmd.ConfigOverrides{},
+	).ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("no cluster reachable: %w", err)
+	}
+
+	client, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("no cluster reachable: %w", err)
+	}
+	return client, nil
+}
+
+func validatePrereqs(ctx context.Context, c *k8sinternal.Client, namespace string) error {
+	if err := c.ValidateSecret(ctx, namespace, "agentctl-credentials"); err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n\n", err)
+		fmt.Fprintln(os.Stderr, secretYAMLExample(namespace))
+		return fmt.Errorf("missing prerequisite: agentctl-credentials Secret")
+	}
+
+	if err := c.ValidateConfigMap(ctx, namespace, jobspec.DefaultConfigMapName); err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n\n", err)
+		fmt.Fprintln(os.Stderr, configMapYAMLExample(namespace))
+		return fmt.Errorf("missing prerequisite: %s ConfigMap", jobspec.DefaultConfigMapName)
+	}
+
+	return nil
+}
+
+func secretYAMLExample(namespace string) string {
+	return fmt.Sprintf(`# Create the credentials Secret:
+kubectl create secret generic agentctl-credentials \
+  --from-literal=GITHUB_TOKEN=<your-token> \
+  -n %s
+
+# Or apply this YAML:
+apiVersion: v1
+kind: Secret
+metadata:
+  name: agentctl-credentials
+  namespace: %s
+type: Opaque
+stringData:
+  GITHUB_TOKEN: "<your-token>"`, namespace, namespace)
+}
+
+func configMapYAMLExample(namespace string) string {
+	return fmt.Sprintf(`# Create the opencode-config ConfigMap. Choose ONE provider:
+
+---
+# Anthropic
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: opencode-config
+  namespace: %s
+data:
+  providers.json: |
+    {
+      "providers": [
+        {
+          "name": "anthropic",
+          "apiKeyEnvar": "ANTHROPIC_API_KEY"
+        }
+      ]
+    }
+
+---
+# OpenRouter
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: opencode-config
+  namespace: %s
+data:
+  providers.json: |
+    {
+      "providers": [
+        {
+          "name": "openrouter",
+          "apiKeyEnvar": "OPENROUTER_API_KEY"
+        }
+      ]
+    }
+
+---
+# LM Studio (local)
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: opencode-config
+  namespace: %s
+data:
+  providers.json: |
+    {
+      "providers": [
+        {
+          "name": "lm-studio",
+          "baseUrl": "http://localhost:1211/v1"
+        }
+      ]
+    }`, namespace, namespace, namespace)
+}
+
+func defaultBranch() (string, error) {
+	out, err := exec.Command("git", "remote", "show", "origin").Output()
+	if err != nil {
+		return "main", nil
+	}
+
+	for _, line := range strings.Split(string(out), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "HEAD branch:") {
+			branch := strings.TrimSpace(strings.TrimPrefix(trimmed, "HEAD branch:"))
+			if branch != "" {
+				return branch, nil
+			}
+		}
+	}
+	return "main", nil
+}
+
+func createJobs(ctx context.Context, w interface{ Write([]byte) (int, error) }, c *k8sinternal.Client, issues []github.Issue, repoURL, defaultBranch string, cfg jobspec.Config, maxParallel int) (created, skipped int) {
+	for _, issue := range issues {
+		exists, err := c.JobExists(ctx, cfg.Namespace, issue.Number)
+		if err != nil {
+			fmt.Fprintf(w, "warning: could not check job for issue %d: %v\n", issue.Number, err)
+			continue
+		}
+		if exists {
+			fmt.Fprintf(w, "skip issue %d (job already exists)\n", issue.Number)
+			skipped++
+			continue
+		}
+
+		jobCfg := cfg
+		jobCfg.MaxParallel = maxParallel
+		job := jobspec.Build(issue, repoURL, defaultBranch, jobCfg)
+
+		if err := c.CreateJob(ctx, cfg.Namespace, job); err != nil {
+			fmt.Fprintf(w, "error creating job for issue %d: %v\n", issue.Number, err)
+			continue
+		}
+
+		fmt.Fprintf(w, "created job agent-issue-%d for \"%s\"\n", issue.Number, issue.Title)
+		created++
+	}
+	return
 }

--- a/internal/git/infer.go
+++ b/internal/git/infer.go
@@ -1,0 +1,65 @@
+package git
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+// InferRepo runs `git remote -v` and returns the GitHub owner/repo.
+func InferRepo() (string, error) {
+	out, err := exec.Command("git", "remote", "-v").Output()
+	if err != nil {
+		return "", fmt.Errorf("not a git repository: %w", err)
+	}
+
+	repo := parseRemoteOutput(string(out))
+	if repo == "" {
+		return "", fmt.Errorf("no GitHub remote found in `git remote -v`")
+	}
+	return repo, nil
+}
+
+// parseRemoteOutput extracts owner/repo from git remote -v output.
+func parseRemoteOutput(output string) string {
+	for _, line := range strings.Split(output, "\n") {
+		repo := extractRepo(line)
+		if repo != "" {
+			return repo
+		}
+	}
+	return ""
+}
+
+// extractRepo parses a single git remote line and returns owner/repo if it's a GitHub URL.
+func extractRepo(line string) string {
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return ""
+	}
+
+	parts := strings.SplitN(line, "\t", 2)
+	if len(parts) < 2 {
+		return ""
+	}
+	url := strings.Fields(parts[1])[0]
+
+	return parseURL(url)
+}
+
+// githubHTTPRe matches HTTPS GitHub URLs like https://github.com/owner/repo.git
+var githubHTTPRe = regexp.MustCompile(`^https?://github\.com/([^/]+/[^/]+?)(?:\.git)?$`)
+
+// githubSSHRe matches SSH GitHub URLs like git@github.com:owner/repo.git
+var githubSSHRe = regexp.MustCompile(`^git@github\.com:([^/]+/[^/]+?)(?:\.git)?$`)
+
+func parseURL(url string) string {
+	if m := githubHTTPRe.FindStringSubmatch(url); m != nil {
+		return m[1]
+	}
+	if m := githubSSHRe.FindStringSubmatch(url); m != nil {
+		return m[1]
+	}
+	return ""
+}

--- a/internal/git/infer_test.go
+++ b/internal/git/infer_test.go
@@ -1,0 +1,80 @@
+package git
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseRemoteOutput_HTTPS(t *testing.T) {
+	output := "origin\thttps://github.com/sebastiaankok/agents.git (fetch)\n" +
+		"origin\thttps://github.com/sebastiaankok/agents.git (push)"
+	got := parseRemoteOutput(output)
+	if got != "sebastiaankok/agents" {
+		t.Fatalf("parseRemoteOutput() = %q, want %q", got, "sebastiaankok/agents")
+	}
+}
+
+func TestParseRemoteOutput_SSH(t *testing.T) {
+	output := "origin\tgit@github.com:sebastiaankok/agents.git (fetch)\n" +
+		"origin\tgit@github.com:sebastiaankok/agents.git (push)"
+	got := parseRemoteOutput(output)
+	if got != "sebastiaankok/agents" {
+		t.Fatalf("parseRemoteOutput() = %q, want %q", got, "sebastiaankok/agents")
+	}
+}
+
+func TestParseRemoteOutput_NoGitSuffix(t *testing.T) {
+	output := "origin\thttps://github.com/owner/repo (fetch)"
+	got := parseRemoteOutput(output)
+	if got != "owner/repo" {
+		t.Fatalf("parseRemoteOutput() = %q, want %q", got, "owner/repo")
+	}
+}
+
+func TestParseRemoteOutput_Empty(t *testing.T) {
+	got := parseRemoteOutput("")
+	if got != "" {
+		t.Fatalf("parseRemoteOutput() = %q, want empty", got)
+	}
+}
+
+func TestParseRemoteOutput_NonGitHub(t *testing.T) {
+	output := "origin\thttps://gitlab.com/owner/repo.git (fetch)"
+	got := parseRemoteOutput(output)
+	if got != "" {
+		t.Fatalf("parseRemoteOutput() = %q, want empty for non-GitHub URL", got)
+	}
+}
+
+func TestExtractRepo_HTTPS(t *testing.T) {
+	line := "origin\thttps://github.com/owner/repo.git (fetch)"
+	got := extractRepo(line)
+	if got != "owner/repo" {
+		t.Fatalf("extractRepo() = %q, want %q", got, "owner/repo")
+	}
+}
+
+func TestExtractRepo_SSH(t *testing.T) {
+	line := "origin\tgit@github.com:owner/repo.git (fetch)"
+	got := extractRepo(line)
+	if got != "owner/repo" {
+		t.Fatalf("extractRepo() = %q, want %q", got, "owner/repo")
+	}
+}
+
+func TestExtractRepo_Empty(t *testing.T) {
+	got := extractRepo("")
+	if got != "" {
+		t.Fatalf("extractRepo() = %q, want empty", got)
+	}
+}
+
+func TestInferRepo_Integration(t *testing.T) {
+	repo, err := InferRepo()
+	if err != nil {
+		t.Skipf("skipping: not in a git repo with GitHub remote (%v)", err)
+	}
+	if !strings.Contains(repo, "/") {
+		t.Errorf("InferRepo() = %q, want owner/repo format", repo)
+	}
+}

--- a/internal/jobspec/build.go
+++ b/internal/jobspec/build.go
@@ -2,6 +2,7 @@ package jobspec
 
 import (
 	"fmt"
+	"strconv"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -24,6 +25,7 @@ type Config struct {
 	ConfigMapName      string
 	ServiceAccountName string
 	Namespace          string
+	MaxParallel        int
 }
 
 // Build returns a suspended Kubernetes Job spec for the given issue.
@@ -44,7 +46,12 @@ func Build(issue github.Issue, repoURL, defaultBranch string, cfg Config) *batch
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("agent-issue-%d", issue.Number),
 			Namespace: cfg.Namespace,
-			Labels:    map[string]string{"issue-number": fmt.Sprintf("%d", issue.Number)},
+			Labels: map[string]string{
+				"issue-number": fmt.Sprintf("%d", issue.Number),
+			},
+			Annotations: map[string]string{
+				"agentctl.max-parallel": strconv.Itoa(cfg.MaxParallel),
+			},
 		},
 		Spec: batchv1.JobSpec{
 			Suspend:                 &suspend,

--- a/internal/jobspec/build_test.go
+++ b/internal/jobspec/build_test.go
@@ -154,5 +154,23 @@ func TestBuild_Namespace(t *testing.T) {
 	}
 }
 
+func TestBuild_MaxParallelAnnotation(t *testing.T) {
+	c := cfg()
+	c.MaxParallel = 5
+	job := jobspec.Build(issue(1), "https://github.com/org/repo", "main", c)
+	got := job.Annotations["agentctl.max-parallel"]
+	if got != "5" {
+		t.Errorf("annotation agentctl.max-parallel = %q, want %q", got, "5")
+	}
+}
+
+func TestBuild_MaxParallelDefault(t *testing.T) {
+	job := jobspec.Build(issue(1), "https://github.com/org/repo", "main", cfg())
+	got := job.Annotations["agentctl.max-parallel"]
+	if got != "0" {
+		t.Errorf("annotation agentctl.max-parallel = %q, want %q (zero value)", got, "0")
+	}
+}
+
 // keep compiler happy
 var _ = fmt.Sprintf


### PR DESCRIPTION
## Summary

Implements `agentctl run` end-to-end to dispatch opencode agent jobs on Kubernetes.

### Changes

- **New `internal/git` package** — infers GitHub repo from `git remote -v`, supports HTTPS and SSH URLs
- **`cmd/agentctl/run.go`** — full implementation:
  - K8s client creation from kubeconfig
  - Prerequisite validation (Secret + ConfigMap) with YAML examples on failure
  - GitHub issue fetching via existing `internal/github` client
  - Idempotent Job creation (skips issues with active Jobs)
  - Flags: `--issue N`, `--namespace`, `--max-parallel`, `--job-image`
- **`jobspec.Config.MaxParallel`** — stored as `agentctl.max-parallel` annotation on Jobs for controller consumption
- **Registered `install` command** in CLI (was implemented but not wired up)

### Acceptance Criteria

- [x] `agentctl run` fetches all open `ready-for-agent` issues and creates suspended Jobs
- [x] `agentctl run --issue 42` targets a single issue
- [x] GitHub repo inferred from `git remote -v`; clear error if not in git repo or no GitHub remote
- [x] Validates `agentctl-credentials` Secret; prints YAML example if missing
- [x] Validates `opencode-config` ConfigMap; prints examples (Anthropic, OpenRouter, LM Studio) if missing
- [x] Idempotent: skips issues with existing Jobs via `issue-number` label check
- [x] `--namespace` flag (default `agent-runners`)
- [x] `--max-parallel N` flag (default 3) as Job annotation
- [x] `--job-image` flag overrides default runner image

### Tests

- 8 new tests in `internal/git/infer_test.go` (parsing logic + integration test)
- 2 new tests in `internal/jobspec/build_test.go` (max-parallel annotation)
- Updated `cmd/agentctl/main_test.go` with flag parsing test using `--dry-run`

All existing tests continue to pass.
"