### PR TITLE
feat: implement controller.Reconcile as pure FIFO unsuspend function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 bin/
-agentctl
-controller
+/agentctl
+/controller

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -10,6 +10,10 @@ import (
 	"time"
 
 	"github.com/sebastiaankok/agents/internal/controller"
+	"github.com/sebastiaankok/agents/internal/k8s"
+	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
 
 func main() {
@@ -21,12 +25,65 @@ func main() {
 	}
 
 	interval := flag.Duration("interval", defaultInterval, "reconcile loop interval")
+	namespace := flag.String("namespace", "agent-runners", "kubernetes namespace for agent jobs")
+	maxParallel := flag.Int("max-parallel", 3, "maximum number of concurrently running agent jobs")
 	flag.Parse()
+
+	cfg, err := rest.InClusterConfig()
+	if err != nil {
+		log.Fatalf("failed to load in-cluster config: %v", err)
+	}
+
+	kubeClient, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		log.Fatalf("failed to create kubernetes client: %v", err)
+	}
+
+	client := k8s.NewClient(kubeClient)
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	log.Printf("controller starting, interval=%s", *interval)
-	runLoop(ctx, *interval, controller.Reconcile)
+	log.Printf("controller starting, interval=%s, namespace=%s, max-parallel=%d", *interval, *namespace, *maxParallel)
+	runLoop(ctx, *interval, func(ctx context.Context) error {
+		return reconcile(ctx, client, *namespace, *maxParallel)
+	})
 	log.Println("controller stopped")
+}
+
+func reconcile(ctx context.Context, client *k8s.Client, namespace string, maxParallel int) error {
+	jobs, err := client.ListJobs(ctx, namespace, "app=agent-job")
+	if err != nil {
+		return err
+	}
+
+	state := buildState(jobs, maxParallel)
+	actions := controller.Reconcile(state)
+
+	for _, action := range actions {
+		switch a := action.(type) {
+		case controller.UnsuspendJob:
+			log.Printf("unsuspending job %q", a.Name)
+			if err := client.UnsuspendJob(ctx, namespace, a.Name); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func buildState(jobs []batchv1.Job, maxParallel int) controller.State {
+	var statuses []controller.JobStatus
+	for _, j := range jobs {
+		statuses = append(statuses, controller.JobStatus{
+			Name:         j.Name,
+			CreationTime: j.CreationTimestamp.Time,
+			Suspended:    j.Spec.Suspend != nil && *j.Spec.Suspend,
+		})
+	}
+	return controller.State{
+		Jobs:        statuses,
+		MaxParallel: maxParallel,
+	}
 }

--- a/internal/controller/reconcile.go
+++ b/internal/controller/reconcile.go
@@ -1,8 +1,62 @@
 package controller
 
-import "context"
+import (
+	"sort"
+	"time"
+)
 
-// Reconcile is a no-op placeholder for the agent job lifecycle reconciler.
-func Reconcile(_ context.Context) error {
-	return nil
+// JobStatus describes a single Agent Job's current state.
+type JobStatus struct {
+	Name         string
+	CreationTime time.Time
+	Suspended    bool
+}
+
+// State is the input to Reconcile. It contains all observed Jobs and configuration.
+type State struct {
+	Jobs        []JobStatus
+	MaxParallel int
+}
+
+// Action represents a decision made by Reconcile.
+type Action interface{}
+
+// UnsuspendJob instructs the controller to unsuspend an Agent Job by name.
+type UnsuspendJob struct {
+	Name string
+}
+
+// Reconcile inspects current Job states and returns a list of actions.
+// It is a pure function — no k8s or GitHub API calls.
+func Reconcile(state State) []Action {
+	running := 0
+	var suspended []JobStatus
+
+	for _, j := range state.Jobs {
+		if j.Suspended {
+			suspended = append(suspended, j)
+		} else {
+			running++
+		}
+	}
+
+	slotsFree := state.MaxParallel - running
+	if slotsFree <= 0 || len(suspended) == 0 {
+		return nil
+	}
+
+	sort.Slice(suspended, func(i, j int) bool {
+		return suspended[i].CreationTime.Before(suspended[j].CreationTime)
+	})
+
+	if slotsFree > len(suspended) {
+		slotsFree = len(suspended)
+	}
+
+	actions := make([]Action, 0, slotsFree)
+	for i := 0; i < slotsFree; i++ {
+		actions = append(actions, UnsuspendJob{Name: suspended[i].Name})
+	}
+
+	return actions
 }

--- a/internal/controller/reconcile_test.go
+++ b/internal/controller/reconcile_test.go
@@ -1,15 +1,121 @@
 package controller_test
 
 import (
-	"context"
 	"testing"
+	"time"
 
 	"github.com/sebastiaankok/agents/internal/controller"
 )
 
-func TestReconcile_NoOp(t *testing.T) {
-	err := controller.Reconcile(context.Background())
-	if err != nil {
-		t.Errorf("Reconcile() error = %v, want nil", err)
+func TestReconcile_EmptyState_NoActions(t *testing.T) {
+	state := controller.State{
+		Jobs:        nil,
+		MaxParallel: 3,
+	}
+
+	actions := controller.Reconcile(state)
+
+	if len(actions) != 0 {
+		t.Errorf("Reconcile() returned %d actions, want 0", len(actions))
+	}
+}
+
+func TestReconcile_AtLimit_NoUnsuspend(t *testing.T) {
+	state := controller.State{
+		Jobs: []controller.JobStatus{
+			{Name: "job-a", CreationTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), Suspended: false},
+			{Name: "job-b", CreationTime: time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC), Suspended: false},
+			{Name: "job-c", CreationTime: time.Date(2025, 1, 3, 0, 0, 0, 0, time.UTC), Suspended: false},
+			{Name: "job-d", CreationTime: time.Date(2025, 1, 4, 0, 0, 0, 0, time.UTC), Suspended: true},
+		},
+		MaxParallel: 3,
+	}
+
+	actions := controller.Reconcile(state)
+
+	if len(actions) != 0 {
+		t.Errorf("Reconcile() returned %d actions, want 0 (at limit)", len(actions))
+		for i, a := range actions {
+			t.Logf("  action[%d]: %v", i, a)
+		}
+	}
+}
+
+func TestReconcile_BelowLimit_UnsuspendOldest(t *testing.T) {
+	state := controller.State{
+		Jobs: []controller.JobStatus{
+			{Name: "job-a", CreationTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), Suspended: false},
+			{Name: "job-b", CreationTime: time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC), Suspended: false},
+			{Name: "job-c", CreationTime: time.Date(2025, 1, 3, 0, 0, 0, 0, time.UTC), Suspended: true},
+			{Name: "job-d", CreationTime: time.Date(2025, 1, 4, 0, 0, 0, 0, time.UTC), Suspended: true},
+		},
+		MaxParallel: 3,
+	}
+
+	actions := controller.Reconcile(state)
+
+	if len(actions) != 1 {
+		t.Fatalf("Reconcile() returned %d actions, want 1", len(actions))
+	}
+
+	unsuspend, ok := actions[0].(controller.UnsuspendJob)
+	if !ok {
+		t.Fatalf("action is %T, want UnsuspendJob", actions[0])
+	}
+	if unsuspend.Name != "job-c" {
+		t.Errorf("UnsuspendJob.Name = %q, want %q (oldest suspended)", unsuspend.Name, "job-c")
+	}
+}
+
+func TestReconcile_MultipleSlotsFree_UnsuspendMultiple(t *testing.T) {
+	state := controller.State{
+		Jobs: []controller.JobStatus{
+			{Name: "job-a", CreationTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), Suspended: false},
+			{Name: "job-b", CreationTime: time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC), Suspended: true},
+			{Name: "job-c", CreationTime: time.Date(2025, 1, 3, 0, 0, 0, 0, time.UTC), Suspended: true},
+			{Name: "job-d", CreationTime: time.Date(2025, 1, 4, 0, 0, 0, 0, time.UTC), Suspended: true},
+		},
+		MaxParallel: 3,
+	}
+
+	actions := controller.Reconcile(state)
+
+	if len(actions) != 2 {
+		t.Fatalf("Reconcile() returned %d actions, want 2", len(actions))
+	}
+
+	wantNames := []string{"job-b", "job-c"}
+	for i, wantName := range wantNames {
+		unsuspend, ok := actions[i].(controller.UnsuspendJob)
+		if !ok {
+			t.Fatalf("action[%d] is %T, want UnsuspendJob", i, actions[i])
+		}
+		if unsuspend.Name != wantName {
+			t.Errorf("action[%d].Name = %q, want %q", i, unsuspend.Name, wantName)
+		}
+	}
+}
+
+func TestReconcile_MaxParallelOne_UnsuspendOldest(t *testing.T) {
+	state := controller.State{
+		Jobs: []controller.JobStatus{
+			{Name: "job-a", CreationTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), Suspended: true},
+			{Name: "job-b", CreationTime: time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC), Suspended: true},
+		},
+		MaxParallel: 1,
+	}
+
+	actions := controller.Reconcile(state)
+
+	if len(actions) != 1 {
+		t.Fatalf("Reconcile() returned %d actions, want 1", len(actions))
+	}
+
+	unsuspend, ok := actions[0].(controller.UnsuspendJob)
+	if !ok {
+		t.Fatalf("action is %T, want UnsuspendJob", actions[0])
+	}
+	if unsuspend.Name != "job-a" {
+		t.Errorf("UnsuspendJob.Name = %q, want %q (oldest suspended)", unsuspend.Name, "job-a")
 	}
 }


### PR DESCRIPTION
## Summary

- `controller.Reconcile(state State) []Action` is now a pure function — no k8s or GitHub API calls
- `State` includes list of Agent Jobs with k8s status and `MaxParallel` config
- `UnsuspendJob{name string}` action type for FIFO unsuspend decisions
- Reconcile unsuspends oldest suspended Jobs (by creation timestamp) when running count < max-parallel, handling multiple free slots in one pass
- Controller binary wired end-to-end: `k8s.ListJobs` → `buildState` → `Reconcile` → apply actions via `k8s.UnsuspendJob`
- Unit tests cover all acceptance criteria: empty state (no-op), at-limit (no unsuspend), below-limit (unsuspend oldest), multiple slots, max-parallel=1

Fixes #9