### PR TITLE
feat: add CI workflow for build, test, lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+          cache: true
+
+      - uses: golangci/golangci-lint-action@v6
+        with:
+          install-mode: "install-only"
+
+      - run: make build
+      - run: make test
+      - run: make lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,7 @@ jobs:
           go-version-file: "go.mod"
           cache: true
 
-      - uses: golangci/golangci-lint-action@v6
-        with:
-          install-mode: "install-only"
+      - run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 
       - run: make build
       - run: make test

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Sets up branch protection on main so CI must pass before merge.
+# Auto-merge is per-PR: run `gh pr merge --auto <pr>` after opening a PR.
+# Requires: gh CLI authenticated with repo scope.
+
+set -euo pipefail
+
+OWNER="sebastiaankok"
+REPO="agents"
+BRANCH="main"
+
+echo "Setting up branch protection on ${OWNER}/${REPO}:${BRANCH} ..."
+
+gh api "repos/${OWNER}/${REPO}/branches/${BRANCH}/protection" \
+  --method PUT \
+  -f enforce_admins=false \
+  -F required_status_checks='{"strict":true,"contexts":["CI"]}' \
+  -F restrictions='{"users":[],"teams":[],"apps":[]}'
+
+echo ""
+echo "Done. Branch protection is configured."
+echo ""
+echo "To auto-merge a PR when CI passes:"
+echo "  gh pr merge --auto <pr-number>"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` that runs `make build`, `make test`, and `make lint` on PRs and pushes to `main`
- Go version pinned from `go.mod` with module caching enabled
- Includes `scripts/setup-branch-protection.sh` to configure branch protection requiring the CI check before merge

## Usage

After merging, run:
```bash
./scripts/setup-branch-protection.sh
```
Then enable auto-merge on PRs with:
```bash
gh pr merge --auto <pr-number>
```