### PR TITLE
feat: controller label lifecycle and failure handling (#11)

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -3,15 +3,19 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 	"time"
 
 	"github.com/sebastiaankok/agents/internal/controller"
+	"github.com/sebastiaankok/agents/internal/github"
 	"github.com/sebastiaankok/agents/internal/k8s"
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
@@ -27,7 +31,12 @@ func main() {
 	interval := flag.Duration("interval", defaultInterval, "reconcile loop interval")
 	namespace := flag.String("namespace", "agent-runners", "kubernetes namespace for agent jobs")
 	maxParallel := flag.Int("max-parallel", 3, "maximum number of concurrently running agent jobs")
+	repo := flag.String("repo", "", "GitHub repository in owner/name format (required)")
 	flag.Parse()
+
+	if *repo == "" {
+		log.Fatal("--repo is required")
+	}
 
 	cfg, err := rest.InClusterConfig()
 	if err != nil {
@@ -40,18 +49,19 @@ func main() {
 	}
 
 	client := k8s.NewClient(kubeClient)
+	ghClient := github.NewClient("")
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	log.Printf("controller starting, interval=%s, namespace=%s, max-parallel=%d", *interval, *namespace, *maxParallel)
+	log.Printf("controller starting, interval=%s, namespace=%s, max-parallel=%d, repo=%s", *interval, *namespace, *maxParallel, *repo)
 	runLoop(ctx, *interval, func(ctx context.Context) error {
-		return reconcile(ctx, client, *namespace, *maxParallel)
+		return reconcile(ctx, client, ghClient, *namespace, *maxParallel, *repo)
 	})
 	log.Println("controller stopped")
 }
 
-func reconcile(ctx context.Context, client *k8s.Client, namespace string, maxParallel int) error {
+func reconcile(ctx context.Context, client *k8s.Client, ghClient *github.Client, namespace string, maxParallel int, repo string) error {
 	jobs, err := client.ListJobs(ctx, namespace, "app=agent-job")
 	if err != nil {
 		return err
@@ -67,6 +77,16 @@ func reconcile(ctx context.Context, client *k8s.Client, namespace string, maxPar
 			if err := client.UnsuspendJob(ctx, namespace, a.Name); err != nil {
 				return err
 			}
+		case controller.UpdateLabel:
+			log.Printf("updating label on issue %d: add=%q remove=%q", a.IssueNumber, a.Add, a.Remove)
+			if err := ghClient.UpdateLabel(ctx, repo, a.IssueNumber, a.Add, a.Remove); err != nil {
+				return fmt.Errorf("update label issue %d: %w", a.IssueNumber, err)
+			}
+		case controller.MarkFailed:
+			log.Printf("marking issue %d as failed", a.IssueNumber)
+			if err := ghClient.UpdateLabel(ctx, repo, a.IssueNumber, "failed", "in-progress"); err != nil {
+				return fmt.Errorf("mark failed issue %d: %w", a.IssueNumber, err)
+			}
 		}
 	}
 
@@ -78,12 +98,36 @@ func buildState(jobs []batchv1.Job, maxParallel int) controller.State {
 	for _, j := range jobs {
 		statuses = append(statuses, controller.JobStatus{
 			Name:         j.Name,
+			IssueNumber:  parseIssueNumber(j.Labels),
 			CreationTime: j.CreationTimestamp.Time,
-			Suspended:    j.Spec.Suspend != nil && *j.Spec.Suspend,
+			Phase:        detectPhase(j),
 		})
 	}
 	return controller.State{
 		Jobs:        statuses,
 		MaxParallel: maxParallel,
 	}
+}
+
+func parseIssueNumber(labels map[string]string) int {
+	n, _ := strconv.Atoi(labels["issue-number"])
+	return n
+}
+
+func detectPhase(j batchv1.Job) controller.Phase {
+	if j.Spec.Suspend != nil && *j.Spec.Suspend {
+		return controller.PhaseSuspended
+	}
+	for _, c := range j.Status.Conditions {
+		if c.Status != corev1.ConditionTrue {
+			continue
+		}
+		switch c.Type {
+		case batchv1.JobComplete:
+			return controller.PhaseSucceeded
+		case batchv1.JobFailed:
+			return controller.PhaseFailed
+		}
+	}
+	return controller.PhaseRunning
 }

--- a/internal/controller/reconcile.go
+++ b/internal/controller/reconcile.go
@@ -5,11 +5,22 @@ import (
 	"time"
 )
 
+// Phase describes a Job's current lifecycle state.
+type Phase string
+
+const (
+	PhaseSuspended Phase = "Suspended"
+	PhaseRunning   Phase = "Running"
+	PhaseSucceeded Phase = "Succeeded"
+	PhaseFailed    Phase = "Failed"
+)
+
 // JobStatus describes a single Agent Job's current state.
 type JobStatus struct {
 	Name         string
+	IssueNumber  int
 	CreationTime time.Time
-	Suspended    bool
+	Phase        Phase
 }
 
 // State is the input to Reconcile. It contains all observed Jobs and configuration.
@@ -26,23 +37,56 @@ type UnsuspendJob struct {
 	Name string
 }
 
+// UpdateLabel instructs the controller to add one label and remove another on a GitHub Issue.
+type UpdateLabel struct {
+	IssueNumber int
+	Add         string
+	Remove      string
+}
+
+// MarkFailed instructs the controller to label a GitHub Issue as failed.
+type MarkFailed struct {
+	IssueNumber int
+}
+
 // Reconcile inspects current Job states and returns a list of actions.
 // It is a pure function — no k8s or GitHub API calls.
 func Reconcile(state State) []Action {
 	running := 0
 	var suspended []JobStatus
+	var actions []Action
 
 	for _, j := range state.Jobs {
-		if j.Suspended {
+		switch j.Phase {
+		case PhaseSuspended:
 			suspended = append(suspended, j)
-		} else {
+		case PhaseRunning:
 			running++
+			if j.IssueNumber != 0 {
+				actions = append(actions, UpdateLabel{
+					IssueNumber: j.IssueNumber,
+					Add:         "in-progress",
+					Remove:      "ready-for-agent",
+				})
+			}
+		case PhaseSucceeded:
+			if j.IssueNumber != 0 {
+				actions = append(actions, UpdateLabel{
+					IssueNumber: j.IssueNumber,
+					Add:         "waiting-for-review",
+					Remove:      "in-progress",
+				})
+			}
+		case PhaseFailed:
+			if j.IssueNumber != 0 {
+				actions = append(actions, MarkFailed{IssueNumber: j.IssueNumber})
+			}
 		}
 	}
 
 	slotsFree := state.MaxParallel - running
 	if slotsFree <= 0 || len(suspended) == 0 {
-		return nil
+		return actions
 	}
 
 	sort.Slice(suspended, func(i, j int) bool {
@@ -53,7 +97,6 @@ func Reconcile(state State) []Action {
 		slotsFree = len(suspended)
 	}
 
-	actions := make([]Action, 0, slotsFree)
 	for i := 0; i < slotsFree; i++ {
 		actions = append(actions, UnsuspendJob{Name: suspended[i].Name})
 	}

--- a/internal/controller/reconcile_test.go
+++ b/internal/controller/reconcile_test.go
@@ -23,10 +23,10 @@ func TestReconcile_EmptyState_NoActions(t *testing.T) {
 func TestReconcile_AtLimit_NoUnsuspend(t *testing.T) {
 	state := controller.State{
 		Jobs: []controller.JobStatus{
-			{Name: "job-a", CreationTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), Suspended: false},
-			{Name: "job-b", CreationTime: time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC), Suspended: false},
-			{Name: "job-c", CreationTime: time.Date(2025, 1, 3, 0, 0, 0, 0, time.UTC), Suspended: false},
-			{Name: "job-d", CreationTime: time.Date(2025, 1, 4, 0, 0, 0, 0, time.UTC), Suspended: true},
+			{Name: "job-a", CreationTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), Phase: controller.PhaseRunning},
+			{Name: "job-b", CreationTime: time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC), Phase: controller.PhaseRunning},
+			{Name: "job-c", CreationTime: time.Date(2025, 1, 3, 0, 0, 0, 0, time.UTC), Phase: controller.PhaseRunning},
+			{Name: "job-d", CreationTime: time.Date(2025, 1, 4, 0, 0, 0, 0, time.UTC), Phase: controller.PhaseSuspended},
 		},
 		MaxParallel: 3,
 	}
@@ -44,10 +44,10 @@ func TestReconcile_AtLimit_NoUnsuspend(t *testing.T) {
 func TestReconcile_BelowLimit_UnsuspendOldest(t *testing.T) {
 	state := controller.State{
 		Jobs: []controller.JobStatus{
-			{Name: "job-a", CreationTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), Suspended: false},
-			{Name: "job-b", CreationTime: time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC), Suspended: false},
-			{Name: "job-c", CreationTime: time.Date(2025, 1, 3, 0, 0, 0, 0, time.UTC), Suspended: true},
-			{Name: "job-d", CreationTime: time.Date(2025, 1, 4, 0, 0, 0, 0, time.UTC), Suspended: true},
+			{Name: "job-a", CreationTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), Phase: controller.PhaseRunning},
+			{Name: "job-b", CreationTime: time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC), Phase: controller.PhaseRunning},
+			{Name: "job-c", CreationTime: time.Date(2025, 1, 3, 0, 0, 0, 0, time.UTC), Phase: controller.PhaseSuspended},
+			{Name: "job-d", CreationTime: time.Date(2025, 1, 4, 0, 0, 0, 0, time.UTC), Phase: controller.PhaseSuspended},
 		},
 		MaxParallel: 3,
 	}
@@ -70,10 +70,10 @@ func TestReconcile_BelowLimit_UnsuspendOldest(t *testing.T) {
 func TestReconcile_MultipleSlotsFree_UnsuspendMultiple(t *testing.T) {
 	state := controller.State{
 		Jobs: []controller.JobStatus{
-			{Name: "job-a", CreationTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), Suspended: false},
-			{Name: "job-b", CreationTime: time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC), Suspended: true},
-			{Name: "job-c", CreationTime: time.Date(2025, 1, 3, 0, 0, 0, 0, time.UTC), Suspended: true},
-			{Name: "job-d", CreationTime: time.Date(2025, 1, 4, 0, 0, 0, 0, time.UTC), Suspended: true},
+			{Name: "job-a", CreationTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), Phase: controller.PhaseRunning},
+			{Name: "job-b", CreationTime: time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC), Phase: controller.PhaseSuspended},
+			{Name: "job-c", CreationTime: time.Date(2025, 1, 3, 0, 0, 0, 0, time.UTC), Phase: controller.PhaseSuspended},
+			{Name: "job-d", CreationTime: time.Date(2025, 1, 4, 0, 0, 0, 0, time.UTC), Phase: controller.PhaseSuspended},
 		},
 		MaxParallel: 3,
 	}
@@ -99,8 +99,8 @@ func TestReconcile_MultipleSlotsFree_UnsuspendMultiple(t *testing.T) {
 func TestReconcile_MaxParallelOne_UnsuspendOldest(t *testing.T) {
 	state := controller.State{
 		Jobs: []controller.JobStatus{
-			{Name: "job-a", CreationTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), Suspended: true},
-			{Name: "job-b", CreationTime: time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC), Suspended: true},
+			{Name: "job-a", CreationTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), Phase: controller.PhaseSuspended},
+			{Name: "job-b", CreationTime: time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC), Phase: controller.PhaseSuspended},
 		},
 		MaxParallel: 1,
 	}
@@ -117,5 +117,119 @@ func TestReconcile_MaxParallelOne_UnsuspendOldest(t *testing.T) {
 	}
 	if unsuspend.Name != "job-a" {
 		t.Errorf("UnsuspendJob.Name = %q, want %q (oldest suspended)", unsuspend.Name, "job-a")
+	}
+}
+
+func TestReconcile_MixedPhases_AllCorrectActions(t *testing.T) {
+	state := controller.State{
+		Jobs: []controller.JobStatus{
+			{Name: "agent-issue-1", IssueNumber: 1, CreationTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), Phase: controller.PhaseRunning},
+			{Name: "agent-issue-2", IssueNumber: 2, CreationTime: time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC), Phase: controller.PhaseSucceeded},
+			{Name: "agent-issue-3", IssueNumber: 3, CreationTime: time.Date(2025, 1, 3, 0, 0, 0, 0, time.UTC), Phase: controller.PhaseFailed},
+			{Name: "agent-issue-4", IssueNumber: 4, CreationTime: time.Date(2025, 1, 4, 0, 0, 0, 0, time.UTC), Phase: controller.PhaseSuspended},
+		},
+		MaxParallel: 2,
+	}
+
+	actions := controller.Reconcile(state)
+
+	// Expect: UpdateLabel(1, in-progress), UpdateLabel(2, waiting-for-review), MarkFailed(3), UnsuspendJob(4)
+	if len(actions) != 4 {
+		t.Fatalf("Reconcile() returned %d actions, want 4: %v", len(actions), actions)
+	}
+
+	ul1, ok := actions[0].(controller.UpdateLabel)
+	if !ok || ul1.IssueNumber != 1 || ul1.Add != "in-progress" {
+		t.Errorf("action[0] = %v, want UpdateLabel{1, in-progress, ready-for-agent}", actions[0])
+	}
+	ul2, ok := actions[1].(controller.UpdateLabel)
+	if !ok || ul2.IssueNumber != 2 || ul2.Add != "waiting-for-review" {
+		t.Errorf("action[1] = %v, want UpdateLabel{2, waiting-for-review, in-progress}", actions[1])
+	}
+	mf, ok := actions[2].(controller.MarkFailed)
+	if !ok || mf.IssueNumber != 3 {
+		t.Errorf("action[2] = %v, want MarkFailed{3}", actions[2])
+	}
+	us, ok := actions[3].(controller.UnsuspendJob)
+	if !ok || us.Name != "agent-issue-4" {
+		t.Errorf("action[3] = %v, want UnsuspendJob{agent-issue-4}", actions[3])
+	}
+}
+
+func TestReconcile_FailedJob_EmitsMarkFailed(t *testing.T) {
+	state := controller.State{
+		Jobs: []controller.JobStatus{
+			{Name: "agent-issue-5", IssueNumber: 5, CreationTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), Phase: controller.PhaseFailed},
+		},
+		MaxParallel: 3,
+	}
+
+	actions := controller.Reconcile(state)
+
+	if len(actions) != 1 {
+		t.Fatalf("Reconcile() returned %d actions, want 1", len(actions))
+	}
+	mf, ok := actions[0].(controller.MarkFailed)
+	if !ok {
+		t.Fatalf("action is %T, want MarkFailed", actions[0])
+	}
+	if mf.IssueNumber != 5 {
+		t.Errorf("MarkFailed.IssueNumber = %d, want 5", mf.IssueNumber)
+	}
+}
+
+func TestReconcile_SucceededJob_EmitsUpdateLabel(t *testing.T) {
+	state := controller.State{
+		Jobs: []controller.JobStatus{
+			{Name: "agent-issue-7", IssueNumber: 7, CreationTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), Phase: controller.PhaseSucceeded},
+		},
+		MaxParallel: 3,
+	}
+
+	actions := controller.Reconcile(state)
+
+	if len(actions) != 1 {
+		t.Fatalf("Reconcile() returned %d actions, want 1", len(actions))
+	}
+	ul, ok := actions[0].(controller.UpdateLabel)
+	if !ok {
+		t.Fatalf("action is %T, want UpdateLabel", actions[0])
+	}
+	if ul.IssueNumber != 7 {
+		t.Errorf("UpdateLabel.IssueNumber = %d, want 7", ul.IssueNumber)
+	}
+	if ul.Add != "waiting-for-review" {
+		t.Errorf("UpdateLabel.Add = %q, want %q", ul.Add, "waiting-for-review")
+	}
+	if ul.Remove != "in-progress" {
+		t.Errorf("UpdateLabel.Remove = %q, want %q", ul.Remove, "in-progress")
+	}
+}
+
+func TestReconcile_RunningJob_EmitsUpdateLabel(t *testing.T) {
+	state := controller.State{
+		Jobs: []controller.JobStatus{
+			{Name: "agent-issue-42", IssueNumber: 42, CreationTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), Phase: controller.PhaseRunning},
+		},
+		MaxParallel: 3,
+	}
+
+	actions := controller.Reconcile(state)
+
+	if len(actions) != 1 {
+		t.Fatalf("Reconcile() returned %d actions, want 1", len(actions))
+	}
+	ul, ok := actions[0].(controller.UpdateLabel)
+	if !ok {
+		t.Fatalf("action is %T, want UpdateLabel", actions[0])
+	}
+	if ul.IssueNumber != 42 {
+		t.Errorf("UpdateLabel.IssueNumber = %d, want 42", ul.IssueNumber)
+	}
+	if ul.Add != "in-progress" {
+		t.Errorf("UpdateLabel.Add = %q, want %q", ul.Add, "in-progress")
+	}
+	if ul.Remove != "ready-for-agent" {
+		t.Errorf("UpdateLabel.Remove = %q, want %q", ul.Remove, "ready-for-agent")
 	}
 }


### PR DESCRIPTION
## Summary

- Add `Phase` type (`Suspended`/`Running`/`Succeeded`/`Failed`) to `JobStatus`, replacing `Suspended bool`
- Add `UpdateLabel` and `MarkFailed` action types to `internal/controller`
- `Reconcile` emits label actions: Running→`in-progress`, Succeeded→`waiting-for-review`, Failed→`MarkFailed`
- `cmd/controller/main.go`: handle new actions via `github.Client`, add `--repo` flag, detect phase from k8s Job conditions

## Test plan

- [x] `TestReconcile_RunningJob_EmitsUpdateLabel` — add `in-progress`, remove `ready-for-agent`
- [x] `TestReconcile_SucceededJob_EmitsUpdateLabel` — add `waiting-for-review`, remove `in-progress`
- [x] `TestReconcile_FailedJob_EmitsMarkFailed` — emits `MarkFailed` action
- [x] `TestReconcile_MixedPhases_AllCorrectActions` — all phases produce correct actions together
- [x] All existing unsuspend tests updated to use `Phase` field
- [x] `go test ./...` passes, `go vet ./...` clean

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)