### PR TITLE
feat: PR auto-merge and done label on merge

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -67,7 +67,12 @@ func reconcile(ctx context.Context, client *k8s.Client, ghClient *github.Client,
 		return err
 	}
 
-	state := buildState(jobs, maxParallel)
+	prStatuses, err := fetchPRStatuses(ctx, ghClient, repo, jobs)
+	if err != nil {
+		return err
+	}
+
+	state := buildState(jobs, prStatuses, maxParallel)
 	actions := controller.Reconcile(state)
 
 	for _, action := range actions {
@@ -87,13 +92,47 @@ func reconcile(ctx context.Context, client *k8s.Client, ghClient *github.Client,
 			if err := ghClient.UpdateLabel(ctx, repo, a.IssueNumber, "failed", "in-progress"); err != nil {
 				return fmt.Errorf("mark failed issue %d: %w", a.IssueNumber, err)
 			}
+		case controller.EnableAutoMerge:
+			log.Printf("enabling auto-merge on PR %d", a.PRNumber)
+			if err := ghClient.EnableAutoMerge(ctx, repo, a.PRNumber); err != nil {
+				return fmt.Errorf("enable auto-merge PR %d: %w", a.PRNumber, err)
+			}
+		case controller.SetDone:
+			log.Printf("setting done on issue %d", a.IssueNumber)
+			if err := ghClient.UpdateLabel(ctx, repo, a.IssueNumber, "done", "waiting-for-review"); err != nil {
+				return fmt.Errorf("set done issue %d: %w", a.IssueNumber, err)
+			}
 		}
 	}
 
 	return nil
 }
 
-func buildState(jobs []batchv1.Job, maxParallel int) controller.State {
+func fetchPRStatuses(ctx context.Context, ghClient *github.Client, repo string, jobs []batchv1.Job) ([]controller.PRStatus, error) {
+	var statuses []controller.PRStatus
+	for _, j := range jobs {
+		issueNum := parseIssueNumber(j.Labels)
+		if issueNum == 0 {
+			continue
+		}
+		branch := fmt.Sprintf("agent/issue-%d", issueNum)
+		pr, ok, err := ghClient.GetPRByBranch(ctx, repo, branch)
+		if err != nil {
+			return nil, fmt.Errorf("get PR for issue %d: %w", issueNum, err)
+		}
+		if !ok {
+			continue
+		}
+		statuses = append(statuses, controller.PRStatus{
+			IssueNumber: issueNum,
+			PRNumber:    pr.Number,
+			Merged:      pr.Merged,
+		})
+	}
+	return statuses, nil
+}
+
+func buildState(jobs []batchv1.Job, prStatuses []controller.PRStatus, maxParallel int) controller.State {
 	var statuses []controller.JobStatus
 	for _, j := range jobs {
 		statuses = append(statuses, controller.JobStatus{
@@ -105,6 +144,7 @@ func buildState(jobs []batchv1.Job, maxParallel int) controller.State {
 	}
 	return controller.State{
 		Jobs:        statuses,
+		PRs:         prStatuses,
 		MaxParallel: maxParallel,
 	}
 }

--- a/internal/controller/reconcile.go
+++ b/internal/controller/reconcile.go
@@ -23,9 +23,10 @@ type JobStatus struct {
 	Phase        Phase
 }
 
-// State is the input to Reconcile. It contains all observed Jobs and configuration.
+// State is the input to Reconcile. It contains all observed Jobs, PRs, and configuration.
 type State struct {
 	Jobs        []JobStatus
+	PRs         []PRStatus
 	MaxParallel int
 }
 
@@ -49,12 +50,34 @@ type MarkFailed struct {
 	IssueNumber int
 }
 
+// EnableAutoMerge instructs the controller to enable squash auto-merge on a PR.
+type EnableAutoMerge struct {
+	PRNumber int
+}
+
+// SetDone instructs the controller to move a GitHub Issue to done state.
+type SetDone struct {
+	IssueNumber int
+}
+
+// PRStatus describes the observed state of a pull request associated with an issue.
+type PRStatus struct {
+	IssueNumber int
+	PRNumber    int
+	Merged      bool
+}
+
 // Reconcile inspects current Job states and returns a list of actions.
 // It is a pure function — no k8s or GitHub API calls.
 func Reconcile(state State) []Action {
 	running := 0
 	var suspended []JobStatus
 	var actions []Action
+
+	prByIssue := make(map[int]PRStatus, len(state.PRs))
+	for _, pr := range state.PRs {
+		prByIssue[pr.IssueNumber] = pr
+	}
 
 	for _, j := range state.Jobs {
 		switch j.Phase {
@@ -76,11 +99,20 @@ func Reconcile(state State) []Action {
 					Add:         "waiting-for-review",
 					Remove:      "in-progress",
 				})
+				if pr, ok := prByIssue[j.IssueNumber]; ok && !pr.Merged {
+					actions = append(actions, EnableAutoMerge{PRNumber: pr.PRNumber})
+				}
 			}
 		case PhaseFailed:
 			if j.IssueNumber != 0 {
 				actions = append(actions, MarkFailed{IssueNumber: j.IssueNumber})
 			}
+		}
+	}
+
+	for _, pr := range state.PRs {
+		if pr.Merged {
+			actions = append(actions, SetDone{IssueNumber: pr.IssueNumber})
 		}
 	}
 

--- a/internal/controller/reconcile_test.go
+++ b/internal/controller/reconcile_test.go
@@ -233,3 +233,89 @@ func TestReconcile_RunningJob_EmitsUpdateLabel(t *testing.T) {
 		t.Errorf("UpdateLabel.Remove = %q, want %q", ul.Remove, "ready-for-agent")
 	}
 }
+
+func TestReconcile_MergedPR_EmitsSetDone(t *testing.T) {
+	state := controller.State{
+		Jobs:        nil,
+		MaxParallel: 3,
+		PRs: []controller.PRStatus{
+			{IssueNumber: 7, PRNumber: 42, Merged: true},
+		},
+	}
+
+	actions := controller.Reconcile(state)
+
+	if len(actions) != 1 {
+		t.Fatalf("Reconcile() returned %d actions, want 1", len(actions))
+	}
+	sd, ok := actions[0].(controller.SetDone)
+	if !ok {
+		t.Fatalf("action is %T, want SetDone", actions[0])
+	}
+	if sd.IssueNumber != 7 {
+		t.Errorf("SetDone.IssueNumber = %d, want 7", sd.IssueNumber)
+	}
+}
+
+func TestReconcile_OpenPR_NoSetDone(t *testing.T) {
+	state := controller.State{
+		Jobs:        nil,
+		MaxParallel: 3,
+		PRs: []controller.PRStatus{
+			{IssueNumber: 8, PRNumber: 43, Merged: false},
+		},
+	}
+
+	actions := controller.Reconcile(state)
+
+	for _, a := range actions {
+		if _, ok := a.(controller.SetDone); ok {
+			t.Errorf("unexpected SetDone action for open PR")
+		}
+	}
+}
+
+func TestReconcile_NoPREntry_NoSetDone(t *testing.T) {
+	state := controller.State{
+		Jobs: []controller.JobStatus{
+			{Name: "agent-issue-9", IssueNumber: 9, CreationTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), Phase: controller.PhaseSucceeded},
+		},
+		MaxParallel: 3,
+		PRs:         nil,
+	}
+
+	actions := controller.Reconcile(state)
+
+	for _, a := range actions {
+		if _, ok := a.(controller.SetDone); ok {
+			t.Errorf("unexpected SetDone action when no PR entry")
+		}
+	}
+}
+
+func TestReconcile_SucceededJobWithPR_EmitsEnableAutoMerge(t *testing.T) {
+	state := controller.State{
+		Jobs: []controller.JobStatus{
+			{Name: "agent-issue-5", IssueNumber: 5, CreationTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), Phase: controller.PhaseSucceeded},
+		},
+		MaxParallel: 3,
+		PRs: []controller.PRStatus{
+			{IssueNumber: 5, PRNumber: 99, Merged: false},
+		},
+	}
+
+	actions := controller.Reconcile(state)
+
+	var foundAutoMerge bool
+	for _, a := range actions {
+		if eam, ok := a.(controller.EnableAutoMerge); ok {
+			foundAutoMerge = true
+			if eam.PRNumber != 99 {
+				t.Errorf("EnableAutoMerge.PRNumber = %d, want 99", eam.PRNumber)
+			}
+		}
+	}
+	if !foundAutoMerge {
+		t.Error("expected EnableAutoMerge action, got none")
+	}
+}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -17,6 +17,13 @@ type Issue struct {
 	State  string `json:"state"`
 }
 
+// PullRequest represents a GitHub pull request.
+type PullRequest struct {
+	Number int    `json:"number"`
+	NodeID string `json:"node_id"`
+	Merged bool   `json:"merged"`
+}
+
 // Client calls the GitHub REST API.
 type Client struct {
 	token   string
@@ -101,6 +108,58 @@ func (c *Client) IsIssueClosed(ctx context.Context, repo string, number int) (bo
 		return false, err
 	}
 	return issue.State == "closed", nil
+}
+
+// GetPRByBranch returns the open PR for head branch in repo. Returns ok=false if none found.
+func (c *Client) GetPRByBranch(ctx context.Context, repo, branch string) (PullRequest, bool, error) {
+	owner := strings.SplitN(repo, "/", 2)[0]
+	path := fmt.Sprintf("/repos/%s/pulls?state=open&head=%s:%s", repo, owner, branch)
+	resp, err := c.do(ctx, http.MethodGet, path, "")
+	if err != nil {
+		return PullRequest{}, false, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var prs []PullRequest
+	if err := json.NewDecoder(resp.Body).Decode(&prs); err != nil {
+		return PullRequest{}, false, err
+	}
+	if len(prs) == 0 {
+		return PullRequest{}, false, nil
+	}
+	return prs[0], true, nil
+}
+
+// GetPR returns a single PR by number, including merged status.
+func (c *Client) GetPR(ctx context.Context, repo string, number int) (PullRequest, error) {
+	path := fmt.Sprintf("/repos/%s/pulls/%d", repo, number)
+	resp, err := c.do(ctx, http.MethodGet, path, "")
+	if err != nil {
+		return PullRequest{}, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var pr PullRequest
+	if err := json.NewDecoder(resp.Body).Decode(&pr); err != nil {
+		return PullRequest{}, err
+	}
+	return pr, nil
+}
+
+// EnableAutoMerge enables squash auto-merge on the given PR via GitHub GraphQL.
+func (c *Client) EnableAutoMerge(ctx context.Context, repo string, prNumber int) error {
+	pr, err := c.GetPR(ctx, repo, prNumber)
+	if err != nil {
+		return fmt.Errorf("get PR node_id: %w", err)
+	}
+	query := fmt.Sprintf(
+		`{"query":"mutation { enablePullRequestAutoMerge(input: {pullRequestId: \"%s\", mergeMethod: SQUASH}) { pullRequest { id } } }"}`,
+		pr.NodeID,
+	)
+	resp, err := c.do(ctx, http.MethodPost, "/graphql", query)
+	if err != nil {
+		return fmt.Errorf("enable auto-merge: %w", err)
+	}
+	_ = resp.Body.Close()
+	return nil
 }
 
 // UpdateLabel adds add label and removes remove label atomically.

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -91,6 +91,80 @@ func TestIsIssueClosed(t *testing.T) {
 	}
 }
 
+func TestGetPRByBranch_Found(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/owner/repo/pulls" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("head") != "owner:agent/issue-7" {
+			t.Errorf("unexpected head param: %s", r.URL.Query().Get("head"))
+		}
+		if r.URL.Query().Get("state") != "open" {
+			t.Errorf("unexpected state param: %s", r.URL.Query().Get("state"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"number":42,"node_id":"PR_node42","merged":false}]`))
+	})
+
+	c, _ := newTestClient(t, handler)
+	pr, ok, err := c.GetPRByBranch(context.Background(), "owner/repo", "agent/issue-7")
+	if err != nil {
+		t.Fatalf("GetPRByBranch() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("GetPRByBranch() ok = false, want true")
+	}
+	if pr.Number != 42 {
+		t.Errorf("PR.Number = %d, want 42", pr.Number)
+	}
+	if pr.NodeID != "PR_node42" {
+		t.Errorf("PR.NodeID = %q, want %q", pr.NodeID, "PR_node42")
+	}
+}
+
+func TestGetPRByBranch_NotFound(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	})
+
+	c, _ := newTestClient(t, handler)
+	_, ok, err := c.GetPRByBranch(context.Background(), "owner/repo", "agent/issue-99")
+	if err != nil {
+		t.Fatalf("GetPRByBranch() error = %v", err)
+	}
+	if ok {
+		t.Error("GetPRByBranch() ok = true, want false for empty result")
+	}
+}
+
+func TestEnableAutoMerge(t *testing.T) {
+	var graphqlCalled bool
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/pulls/42":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"number":42,"node_id":"PR_node42","merged":false}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/graphql":
+			graphqlCalled = true
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{"enablePullRequestAutoMerge":{"pullRequest":{"id":"PR_node42"}}}}`))
+		default:
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	c, _ := newTestClient(t, handler)
+	err := c.EnableAutoMerge(context.Background(), "owner/repo", 42)
+	if err != nil {
+		t.Fatalf("EnableAutoMerge() error = %v", err)
+	}
+	if !graphqlCalled {
+		t.Error("GraphQL endpoint not called")
+	}
+}
+
 func TestUpdateLabel(t *testing.T) {
 	var addCalled, removeCalled bool
 


### PR DESCRIPTION
## Summary

- Extends reconcile with `EnableAutoMerge{PRNumber}` and `SetDone{IssueNumber}` action types
- `PRStatus` added to `State`; Reconcile emits `EnableAutoMerge` for succeeded jobs with open PRs, `SetDone` when a PR is detected as merged
- GitHub client gains `GetPRByBranch` (polls open PRs by `agent/issue-{n}` branch) and `EnableAutoMerge` (GraphQL squash auto-merge mutation)
- Controller fetches PR statuses each reconcile cycle and dispatches both new action types

Closes #12

## Test plan

- [x] `TestReconcile_MergedPR_EmitsSetDone` — merged PR → SetDone
- [x] `TestReconcile_OpenPR_NoSetDone` — open PR → no action
- [x] `TestReconcile_NoPREntry_NoSetDone` — no PR found → no action
- [x] `TestReconcile_SucceededJobWithPR_EmitsEnableAutoMerge` — succeeded job + open PR → EnableAutoMerge
- [x] `TestGetPRByBranch_Found` / `TestGetPRByBranch_NotFound` — PR lookup
- [x] `TestEnableAutoMerge` — GraphQL call verified via httptest

🤖 Generated with [Claude Code](https://claude.com/claude-code)