### PR TITLE
feat: GitHub Actions publish workflow for all artifacts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,92 @@
+name: Publish
+
+on:
+  push:
+    branches: [main]
+
+env:
+  REGISTRY: ghcr.io
+  CONTROLLER_IMAGE: ghcr.io/sebastiaankok/agents/controller
+  RUNNER_IMAGE: ghcr.io/sebastiaankok/agents/opencode-runner
+
+jobs:
+  release-binaries:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    strategy:
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+          cache: true
+
+      - name: Build agentctl
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          go build -o agentctl-${{ matrix.goos }}-${{ matrix.goarch }} ./cmd/agentctl
+
+      - name: Upload to release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.sha }}
+          files: agentctl-${{ matrix.goos }}-${{ matrix.goarch }}
+
+  build-controller:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push controller
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: cmd/controller/Dockerfile
+          push: true
+          tags: |
+            ${{ env.CONTROLLER_IMAGE }}:latest
+            ${{ env.CONTROLLER_IMAGE }}:${{ github.sha }}
+
+  build-runner:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push opencode-runner
+        uses: docker/build-push-action@v5
+        with:
+          context: opencode-runner
+          push: true
+          tags: |
+            ${{ env.RUNNER_IMAGE }}:latest
+            ${{ env.RUNNER_IMAGE }}:${{ github.sha }}

--- a/cmd/controller/Dockerfile
+++ b/cmd/controller/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.26-alpine AS builder
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o /controller ./cmd/controller
+
+FROM gcr.io/distroless/static:nonroot
+COPY --from=builder /controller /controller
+ENTRYPOINT ["/controller"]

--- a/internal/workflows/publish_test.go
+++ b/internal/workflows/publish_test.go
@@ -1,0 +1,143 @@
+package workflows_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func workflowPath(name string) string {
+	_, file, _, _ := runtime.Caller(0)
+	root := filepath.Join(filepath.Dir(file), "..", "..")
+	return filepath.Join(root, ".github", "workflows", name)
+}
+
+func dockerfilePath(rel string) string {
+	_, file, _, _ := runtime.Caller(0)
+	root := filepath.Join(filepath.Dir(file), "..", "..")
+	return filepath.Join(root, rel)
+}
+
+func readWorkflow(t *testing.T, name string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(workflowPath(name))
+	if err != nil {
+		t.Fatalf("workflow %s not found: %v", name, err)
+	}
+	var wf map[string]any
+	if err := yaml.Unmarshal(data, &wf); err != nil {
+		t.Fatalf("workflow %s invalid YAML: %v", name, err)
+	}
+	return wf
+}
+
+// Cycle 1 – tracer bullet: publish.yml exists and triggers on push to main.
+func TestPublishWorkflow_Exists(t *testing.T) {
+	wf := readWorkflow(t, "publish.yml")
+	on, ok := wf["on"].(map[string]any)
+	if !ok {
+		t.Fatal("publish.yml missing 'on' key")
+	}
+	push, ok := on["push"].(map[string]any)
+	if !ok {
+		t.Fatal("publish.yml missing 'on.push'")
+	}
+	branches, ok := push["branches"].([]any)
+	if !ok {
+		t.Fatal("publish.yml missing 'on.push.branches'")
+	}
+	var found bool
+	for _, b := range branches {
+		if b == "main" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("publish.yml does not trigger on push to main")
+	}
+}
+
+// Cycle 2 – agentctl binary built for linux/amd64 and darwin/arm64.
+func TestPublishWorkflow_AgentctlBothPlatforms(t *testing.T) {
+	data, err := os.ReadFile(workflowPath("publish.yml"))
+	if err != nil {
+		t.Fatalf("publish.yml not found: %v", err)
+	}
+	content := string(data)
+	for _, want := range []string{"linux", "amd64", "darwin", "arm64"} {
+		if !strings.Contains(content, want) {
+			t.Errorf("publish.yml missing platform %q", want)
+		}
+	}
+}
+
+// Cycle 3 – agentctl binary attached to GitHub Release.
+func TestPublishWorkflow_AgentctlRelease(t *testing.T) {
+	data, err := os.ReadFile(workflowPath("publish.yml"))
+	if err != nil {
+		t.Fatalf("publish.yml not found: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "softprops/action-gh-release") && !strings.Contains(content, "gh release") {
+		t.Error("publish.yml does not attach binaries to GitHub Release")
+	}
+}
+
+// Cycle 4 – controller image pushed with correct name, latest and SHA tags.
+func TestPublishWorkflow_ControllerImage(t *testing.T) {
+	data, err := os.ReadFile(workflowPath("publish.yml"))
+	if err != nil {
+		t.Fatalf("publish.yml not found: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "ghcr.io/sebastiaankok/agents/controller") {
+		t.Error("publish.yml missing controller image name")
+	}
+	if !strings.Contains(content, ":latest") && !strings.Contains(content, "latest") {
+		t.Error("publish.yml missing :latest tag for controller")
+	}
+	if !strings.Contains(content, "github.sha") {
+		t.Error("publish.yml missing SHA tag")
+	}
+}
+
+// Cycle 5 – opencode-runner image pushed with correct name, latest and SHA tags.
+func TestPublishWorkflow_OpenCodeRunnerImage(t *testing.T) {
+	data, err := os.ReadFile(workflowPath("publish.yml"))
+	if err != nil {
+		t.Fatalf("publish.yml not found: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "ghcr.io/sebastiaankok/agents/opencode-runner") {
+		t.Error("publish.yml missing opencode-runner image name")
+	}
+}
+
+// Cycle 6 – controller Dockerfile exists.
+func TestControllerDockerfile_Exists(t *testing.T) {
+	path := dockerfilePath("cmd/controller/Dockerfile")
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		t.Fatalf("cmd/controller/Dockerfile not found")
+	}
+}
+
+// Cycle 7 – controller Dockerfile uses scratch or distroless base for final stage.
+func TestControllerDockerfile_CopiesBinary(t *testing.T) {
+	path := dockerfilePath("cmd/controller/Dockerfile")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("cmd/controller/Dockerfile read error: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "COPY") && !strings.Contains(content, "ADD") {
+		t.Error("controller Dockerfile does not copy binary")
+	}
+	if !strings.Contains(content, "ENTRYPOINT") && !strings.Contains(content, "CMD") {
+		t.Error("controller Dockerfile missing ENTRYPOINT/CMD")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/publish.yml` — unified workflow triggered on push to `main`: builds `agentctl` binaries (linux/amd64, darwin/arm64) attached to a GitHub Release via `softprops/action-gh-release`, builds and pushes controller image, builds and pushes opencode-runner image
- Adds `cmd/controller/Dockerfile` — multi-stage build with `distroless/static:nonroot` final image
- Images tagged `:latest` and `:<sha>` on every push to `main`
- Adds `internal/workflows/publish_test.go` — TDD structural tests (red→green) verifying workflow triggers, platform matrix, release upload, image names, and Dockerfile shape

Closes #13

## Test plan

- [x] `go test ./internal/workflows/` — all 7 tests pass
- [x] `go test ./...` — all packages pass
- [ ] CI run on merge validates lint, build, and triggers publish jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)