### PR TITLE
feat: blocked issue detection with 5-minute poll

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -6,10 +6,12 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 	"time"
 
 	"github.com/sebastiaankok/agents/internal/controller"
+	"github.com/sebastiaankok/agents/internal/github"
 	"github.com/sebastiaankok/agents/internal/k8s"
 	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/client-go/kubernetes"
@@ -27,7 +29,12 @@ func main() {
 	interval := flag.Duration("interval", defaultInterval, "reconcile loop interval")
 	namespace := flag.String("namespace", "agent-runners", "kubernetes namespace for agent jobs")
 	maxParallel := flag.Int("max-parallel", 3, "maximum number of concurrently running agent jobs")
+	repo := flag.String("repo", os.Getenv("GITHUB_REPO"), "github repository (owner/name)")
 	flag.Parse()
+
+	if *repo == "" {
+		log.Fatal("--repo (or GITHUB_REPO env var) is required")
+	}
 
 	cfg, err := rest.InClusterConfig()
 	if err != nil {
@@ -39,32 +46,33 @@ func main() {
 		log.Fatalf("failed to create kubernetes client: %v", err)
 	}
 
-	client := k8s.NewClient(kubeClient)
+	k8sClient := k8s.NewClient(kubeClient)
+	ghClient := github.NewClient("")
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	log.Printf("controller starting, interval=%s, namespace=%s, max-parallel=%d", *interval, *namespace, *maxParallel)
+	log.Printf("controller starting, interval=%s, namespace=%s, max-parallel=%d, repo=%s", *interval, *namespace, *maxParallel, *repo)
 	runLoop(ctx, *interval, func(ctx context.Context) error {
-		return reconcile(ctx, client, *namespace, *maxParallel)
+		return reconcile(ctx, k8sClient, ghClient, *repo, *namespace, *maxParallel)
 	})
 	log.Println("controller stopped")
 }
 
-func reconcile(ctx context.Context, client *k8s.Client, namespace string, maxParallel int) error {
-	jobs, err := client.ListJobs(ctx, namespace, "app=agent-job")
+func reconcile(ctx context.Context, k8sClient *k8s.Client, ghClient *github.Client, repo, namespace string, maxParallel int) error {
+	jobs, err := k8sClient.ListJobs(ctx, namespace, "app=agent-job")
 	if err != nil {
 		return err
 	}
 
-	state := buildState(jobs, maxParallel)
+	state := buildState(ctx, ghClient, repo, jobs, maxParallel)
 	actions := controller.Reconcile(state)
 
 	for _, action := range actions {
 		switch a := action.(type) {
 		case controller.UnsuspendJob:
 			log.Printf("unsuspending job %q", a.Name)
-			if err := client.UnsuspendJob(ctx, namespace, a.Name); err != nil {
+			if err := k8sClient.UnsuspendJob(ctx, namespace, a.Name); err != nil {
 				return err
 			}
 		}
@@ -73,17 +81,58 @@ func reconcile(ctx context.Context, client *k8s.Client, namespace string, maxPar
 	return nil
 }
 
-func buildState(jobs []batchv1.Job, maxParallel int) controller.State {
+func buildState(ctx context.Context, ghClient *github.Client, repo string, jobs []batchv1.Job, maxParallel int) controller.State {
 	var statuses []controller.JobStatus
 	for _, j := range jobs {
-		statuses = append(statuses, controller.JobStatus{
+		suspended := j.Spec.Suspend != nil && *j.Spec.Suspend
+		js := controller.JobStatus{
 			Name:         j.Name,
 			CreationTime: j.CreationTimestamp.Time,
-			Suspended:    j.Spec.Suspend != nil && *j.Spec.Suspend,
-		})
+			Suspended:    suspended,
+		}
+		if suspended {
+			js.BlockingIssues = fetchBlockingIssues(ctx, ghClient, repo, j)
+		}
+		statuses = append(statuses, js)
 	}
 	return controller.State{
 		Jobs:        statuses,
 		MaxParallel: maxParallel,
 	}
+}
+
+func fetchBlockingIssues(ctx context.Context, ghClient *github.Client, repo string, job batchv1.Job) []controller.BlockingIssue {
+	issueNumberStr, ok := job.Labels["issue-number"]
+	if !ok {
+		return nil
+	}
+	issueNumber, err := strconv.Atoi(issueNumberStr)
+	if err != nil {
+		return nil
+	}
+
+	issue, err := ghClient.GetIssue(ctx, repo, issueNumber)
+	if err != nil {
+		log.Printf("warning: failed to fetch issue %d for job %s: %v", issueNumber, job.Name, err)
+		return nil
+	}
+
+	blockedBy := github.ParseBlockedBy(issue.Body)
+	if len(blockedBy) == 0 {
+		return nil
+	}
+
+	var blocking []controller.BlockingIssue
+	for _, n := range blockedBy {
+		closed, err := ghClient.IsIssueClosed(ctx, repo, n)
+		if err != nil {
+			log.Printf("warning: failed to check blocking issue #%d: %v", n, err)
+			continue
+		}
+		blocking = append(blocking, controller.BlockingIssue{
+			Number: n,
+			Closed: closed,
+		})
+	}
+	return blocking
 }

--- a/internal/controller/reconcile.go
+++ b/internal/controller/reconcile.go
@@ -5,11 +5,18 @@ import (
 	"time"
 )
 
+// BlockingIssue represents a GitHub issue referenced by "Blocked by #N".
+type BlockingIssue struct {
+	Number int
+	Closed bool
+}
+
 // JobStatus describes a single Agent Job's current state.
 type JobStatus struct {
-	Name         string
-	CreationTime time.Time
-	Suspended    bool
+	Name           string
+	CreationTime   time.Time
+	Suspended      bool
+	BlockingIssues []BlockingIssue
 }
 
 // State is the input to Reconcile. It contains all observed Jobs and configuration.
@@ -33,9 +40,9 @@ func Reconcile(state State) []Action {
 	var suspended []JobStatus
 
 	for _, j := range state.Jobs {
-		if j.Suspended {
+		if j.Suspended && !jobHasOpenBlocker(j) {
 			suspended = append(suspended, j)
-		} else {
+		} else if !j.Suspended {
 			running++
 		}
 	}
@@ -59,4 +66,14 @@ func Reconcile(state State) []Action {
 	}
 
 	return actions
+}
+
+// jobHasOpenBlocker returns true if any of the job's blocking issues are still open.
+func jobHasOpenBlocker(j JobStatus) bool {
+	for _, b := range j.BlockingIssues {
+		if !b.Closed {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/controller/reconcile_test.go
+++ b/internal/controller/reconcile_test.go
@@ -96,6 +96,107 @@ func TestReconcile_MultipleSlotsFree_UnsuspendMultiple(t *testing.T) {
 	}
 }
 
+func TestReconcile_SingleBlockerOpen_StaysSuspended(t *testing.T) {
+	state := controller.State{
+		Jobs: []controller.JobStatus{
+			{Name: "job-a", CreationTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), Suspended: false},
+			{Name: "job-b", CreationTime: time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC), Suspended: true,
+				BlockingIssues: []controller.BlockingIssue{{Number: 99, Closed: false}}},
+		},
+		MaxParallel: 3,
+	}
+	actions := controller.Reconcile(state)
+	if len(actions) != 0 {
+		t.Errorf("Reconcile() returned %d actions, want 0 (blocked by open issue)", len(actions))
+	}
+}
+
+func TestReconcile_SingleBlockerClosed_Eligible(t *testing.T) {
+	state := controller.State{
+		Jobs: []controller.JobStatus{
+			{Name: "job-a", CreationTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), Suspended: false},
+			{Name: "job-b", CreationTime: time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC), Suspended: true,
+				BlockingIssues: []controller.BlockingIssue{{Number: 99, Closed: true}}},
+		},
+		MaxParallel: 3,
+	}
+	actions := controller.Reconcile(state)
+	if len(actions) != 1 {
+		t.Fatalf("Reconcile() returned %d actions, want 1", len(actions))
+	}
+	unsuspend, ok := actions[0].(controller.UnsuspendJob)
+	if !ok {
+		t.Fatalf("action is %T, want UnsuspendJob", actions[0])
+	}
+	if unsuspend.Name != "job-b" {
+		t.Errorf("UnsuspendJob.Name = %q, want %q", unsuspend.Name, "job-b")
+	}
+}
+
+func TestReconcile_MultipleBlockersMixed_StaysSuspended(t *testing.T) {
+	state := controller.State{
+		Jobs: []controller.JobStatus{
+			{Name: "job-a", CreationTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), Suspended: false},
+			{Name: "job-b", CreationTime: time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC), Suspended: true,
+				BlockingIssues: []controller.BlockingIssue{
+					{Number: 1, Closed: true},
+					{Number: 2, Closed: false},
+				}},
+		},
+		MaxParallel: 3,
+	}
+	actions := controller.Reconcile(state)
+	if len(actions) != 0 {
+		t.Errorf("Reconcile() returned %d actions, want 0 (mixed blockers, one open)", len(actions))
+	}
+}
+
+func TestReconcile_AllBlockersClosed_Eligible(t *testing.T) {
+	state := controller.State{
+		Jobs: []controller.JobStatus{
+			{Name: "job-a", CreationTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), Suspended: false},
+			{Name: "job-b", CreationTime: time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC), Suspended: true,
+				BlockingIssues: []controller.BlockingIssue{
+					{Number: 1, Closed: true},
+					{Number: 2, Closed: true},
+				}},
+		},
+		MaxParallel: 3,
+	}
+	actions := controller.Reconcile(state)
+	if len(actions) != 1 {
+		t.Fatalf("Reconcile() returned %d actions, want 1", len(actions))
+	}
+	unsuspend, ok := actions[0].(controller.UnsuspendJob)
+	if !ok {
+		t.Fatalf("action is %T, want UnsuspendJob", actions[0])
+	}
+	if unsuspend.Name != "job-b" {
+		t.Errorf("UnsuspendJob.Name = %q, want %q", unsuspend.Name, "job-b")
+	}
+}
+
+func TestReconcile_NoBlockers_Eligible(t *testing.T) {
+	state := controller.State{
+		Jobs: []controller.JobStatus{
+			{Name: "job-a", CreationTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), Suspended: false},
+			{Name: "job-b", CreationTime: time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC), Suspended: true},
+		},
+		MaxParallel: 3,
+	}
+	actions := controller.Reconcile(state)
+	if len(actions) != 1 {
+		t.Fatalf("Reconcile() returned %d actions, want 1", len(actions))
+	}
+	unsuspend, ok := actions[0].(controller.UnsuspendJob)
+	if !ok {
+		t.Fatalf("action is %T, want UnsuspendJob", actions[0])
+	}
+	if unsuspend.Name != "job-b" {
+		t.Errorf("UnsuspendJob.Name = %q, want %q", unsuspend.Name, "job-b")
+	}
+}
+
 func TestReconcile_MaxParallelOne_UnsuspendOldest(t *testing.T) {
 	state := controller.State{
 		Jobs: []controller.JobStatus{


### PR DESCRIPTION
## Summary

- Extends `controller.Reconcile` to handle blocked Jobs
- A suspended Job is blocked if its issue body contains `Blocked by #N` and that issue is still open
- Blocked Jobs stay suspended until all blocking issues close
- Controller fetches blocking issue states from GitHub API on each reconcile cycle

## Changes

- `internal/controller/reconcile.go`: Added `BlockingIssue` type, `BlockingIssues` field on `JobStatus`, `jobHasOpenBlocker` helper, and updated `Reconcile` to skip blocked jobs
- `internal/controller/reconcile_test.go`: 5 new tests — single blocker open, single blocker closed, multiple mixed, all closed, no blockers
- `cmd/controller/main.go`: Wired up GitHub client, fetches issue body for each suspended job, parses `Blocked by #N` refs, checks issue states, populates `BlockingIssues` on State

Closes #10