### PR TITLE
feat: Controller — blocked issue detection with 5-minute poll

### DIFF
--- a/internal/controller/reconcile.go
+++ b/internal/controller/reconcile.go
@@ -15,19 +15,27 @@ const (
 	PhaseFailed    Phase = "Failed"
 )
 
+// IssueState holds the open/closed status of a blocking GitHub issue.
+type IssueState struct {
+	Number int
+	Open   bool
+}
+
 // JobStatus describes a single Agent Job's current state.
 type JobStatus struct {
 	Name         string
 	IssueNumber  int
 	CreationTime time.Time
 	Phase        Phase
+	BlockedBy    []int // issue numbers from "Blocked by #N" lines
 }
 
 // State is the input to Reconcile. It contains all observed Jobs, PRs, and configuration.
 type State struct {
-	Jobs        []JobStatus
-	PRs         []PRStatus
-	MaxParallel int
+	Jobs           []JobStatus
+	PRs            []PRStatus
+	MaxParallel    int
+	BlockingIssues []IssueState // open/closed status for all issues referenced in BlockedBy fields
 }
 
 // Action represents a decision made by Reconcile.
@@ -116,21 +124,42 @@ func Reconcile(state State) []Action {
 		}
 	}
 
+	openIssues := make(map[int]bool, len(state.BlockingIssues))
+	for _, s := range state.BlockingIssues {
+		if s.Open {
+			openIssues[s.Number] = true
+		}
+	}
+
+	var eligible []JobStatus
+	for _, j := range suspended {
+		blocked := false
+		for _, n := range j.BlockedBy {
+			if openIssues[n] {
+				blocked = true
+				break
+			}
+		}
+		if !blocked {
+			eligible = append(eligible, j)
+		}
+	}
+
 	slotsFree := state.MaxParallel - running
-	if slotsFree <= 0 || len(suspended) == 0 {
+	if slotsFree <= 0 || len(eligible) == 0 {
 		return actions
 	}
 
-	sort.Slice(suspended, func(i, j int) bool {
-		return suspended[i].CreationTime.Before(suspended[j].CreationTime)
+	sort.Slice(eligible, func(i, j int) bool {
+		return eligible[i].CreationTime.Before(eligible[j].CreationTime)
 	})
 
-	if slotsFree > len(suspended) {
-		slotsFree = len(suspended)
+	if slotsFree > len(eligible) {
+		slotsFree = len(eligible)
 	}
 
 	for i := 0; i < slotsFree; i++ {
-		actions = append(actions, UnsuspendJob{Name: suspended[i].Name})
+		actions = append(actions, UnsuspendJob{Name: eligible[i].Name})
 	}
 
 	return actions

--- a/internal/controller/reconcile_test.go
+++ b/internal/controller/reconcile_test.go
@@ -319,3 +319,89 @@ func TestReconcile_SucceededJobWithPR_EmitsEnableAutoMerge(t *testing.T) {
 		t.Error("expected EnableAutoMerge action, got none")
 	}
 }
+
+func TestReconcile_SingleBlockerOpen_StaysSuspended(t *testing.T) {
+	state := controller.State{
+		Jobs: []controller.JobStatus{
+			{Name: "agent-issue-20", IssueNumber: 20, CreationTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), Phase: controller.PhaseSuspended, BlockedBy: []int{5}},
+		},
+		MaxParallel:    3,
+		BlockingIssues: []controller.IssueState{{Number: 5, Open: true}},
+	}
+
+	actions := controller.Reconcile(state)
+
+	for _, a := range actions {
+		if _, ok := a.(controller.UnsuspendJob); ok {
+			t.Errorf("expected no UnsuspendJob while blocker #5 is open")
+		}
+	}
+}
+
+func TestReconcile_SingleBlockerClosed_Eligible(t *testing.T) {
+	state := controller.State{
+		Jobs: []controller.JobStatus{
+			{Name: "agent-issue-21", IssueNumber: 21, CreationTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), Phase: controller.PhaseSuspended, BlockedBy: []int{5}},
+		},
+		MaxParallel:    3,
+		BlockingIssues: []controller.IssueState{{Number: 5, Open: false}},
+	}
+
+	actions := controller.Reconcile(state)
+
+	var found bool
+	for _, a := range actions {
+		if u, ok := a.(controller.UnsuspendJob); ok && u.Name == "agent-issue-21" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected UnsuspendJob for agent-issue-21 when blocker #5 is closed")
+	}
+}
+
+func TestReconcile_MultipleBlockersMixed_StaysSuspended(t *testing.T) {
+	state := controller.State{
+		Jobs: []controller.JobStatus{
+			{Name: "agent-issue-22", IssueNumber: 22, CreationTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), Phase: controller.PhaseSuspended, BlockedBy: []int{5, 6}},
+		},
+		MaxParallel: 3,
+		BlockingIssues: []controller.IssueState{
+			{Number: 5, Open: false},
+			{Number: 6, Open: true},
+		},
+	}
+
+	actions := controller.Reconcile(state)
+
+	for _, a := range actions {
+		if _, ok := a.(controller.UnsuspendJob); ok {
+			t.Errorf("expected no UnsuspendJob while blocker #6 is still open")
+		}
+	}
+}
+
+func TestReconcile_AllBlockersClosed_Eligible(t *testing.T) {
+	state := controller.State{
+		Jobs: []controller.JobStatus{
+			{Name: "agent-issue-23", IssueNumber: 23, CreationTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), Phase: controller.PhaseSuspended, BlockedBy: []int{5, 6}},
+		},
+		MaxParallel: 3,
+		BlockingIssues: []controller.IssueState{
+			{Number: 5, Open: false},
+			{Number: 6, Open: false},
+		},
+	}
+
+	actions := controller.Reconcile(state)
+
+	var found bool
+	for _, a := range actions {
+		if u, ok := a.(controller.UnsuspendJob); ok && u.Name == "agent-issue-23" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected UnsuspendJob for agent-issue-23 when all blockers closed")
+	}
+}


### PR DESCRIPTION
Closes #10

## Summary

- Added `IssueState` type (Number, Open) to represent blocking issue status
- Extended `State` with `BlockingIssues []IssueState` and `JobStatus` with `BlockedBy []int`
- `Reconcile` now skips unsuspending any Job where any `BlockedBy` issue is open; unblocked jobs follow existing FIFO logic

## Test plan

- [x] `TestReconcile_SingleBlockerOpen_StaysSuspended` — job with open blocker stays suspended
- [x] `TestReconcile_SingleBlockerClosed_Eligible` — job with closed blocker gets unsuspended
- [x] `TestReconcile_MultipleBlockersMixed_StaysSuspended` — one open blocker still blocks
- [x] `TestReconcile_AllBlockersClosed_Eligible` — all closed → eligible
- [x] All 13 existing tests continue to pass (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)