### PR TITLE
fix: stop controller looping on label transitions

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -75,6 +75,13 @@ func reconcile(ctx context.Context, client *k8s.Client, ghClient *github.Client,
 	state := buildState(jobs, prStatuses, maxParallel)
 	actions := controller.Reconcile(state)
 
+	jobNameByIssue := make(map[int]string, len(jobs))
+	for _, j := range jobs {
+		if n := parseIssueNumber(j.Labels); n != 0 {
+			jobNameByIssue[n] = j.Name
+		}
+	}
+
 	for _, action := range actions {
 		switch a := action.(type) {
 		case controller.UnsuspendJob:
@@ -87,10 +94,20 @@ func reconcile(ctx context.Context, client *k8s.Client, ghClient *github.Client,
 			if err := ghClient.UpdateLabel(ctx, repo, a.IssueNumber, a.Add, a.Remove); err != nil {
 				return fmt.Errorf("update label issue %d: %w", a.IssueNumber, err)
 			}
+			if jobName := jobNameByIssue[a.IssueNumber]; jobName != "" {
+				if err := client.SetJobAnnotation(ctx, namespace, jobName, "agents.io/issue-label", a.Add); err != nil {
+					return fmt.Errorf("annotate job %s: %w", jobName, err)
+				}
+			}
 		case controller.MarkFailed:
 			log.Printf("marking issue %d as failed", a.IssueNumber)
 			if err := ghClient.UpdateLabel(ctx, repo, a.IssueNumber, "failed", "in-progress"); err != nil {
 				return fmt.Errorf("mark failed issue %d: %w", a.IssueNumber, err)
+			}
+			if jobName := jobNameByIssue[a.IssueNumber]; jobName != "" {
+				if err := client.SetJobAnnotation(ctx, namespace, jobName, "agents.io/issue-label", "failed"); err != nil {
+					return fmt.Errorf("annotate job %s: %w", jobName, err)
+				}
 			}
 		case controller.EnableAutoMerge:
 			log.Printf("enabling auto-merge on PR %d", a.PRNumber)
@@ -101,6 +118,11 @@ func reconcile(ctx context.Context, client *k8s.Client, ghClient *github.Client,
 			log.Printf("setting done on issue %d", a.IssueNumber)
 			if err := ghClient.UpdateLabel(ctx, repo, a.IssueNumber, "done", "waiting-for-review"); err != nil {
 				return fmt.Errorf("set done issue %d: %w", a.IssueNumber, err)
+			}
+			if jobName := jobNameByIssue[a.IssueNumber]; jobName != "" {
+				if err := client.SetJobAnnotation(ctx, namespace, jobName, "agents.io/issue-label", "done"); err != nil {
+					return fmt.Errorf("annotate job %s: %w", jobName, err)
+				}
 			}
 		}
 	}
@@ -136,10 +158,11 @@ func buildState(jobs []batchv1.Job, prStatuses []controller.PRStatus, maxParalle
 	var statuses []controller.JobStatus
 	for _, j := range jobs {
 		statuses = append(statuses, controller.JobStatus{
-			Name:         j.Name,
-			IssueNumber:  parseIssueNumber(j.Labels),
-			CreationTime: j.CreationTimestamp.Time,
-			Phase:        detectPhase(j),
+			Name:              j.Name,
+			IssueNumber:       parseIssueNumber(j.Labels),
+			CreationTime:      j.CreationTimestamp.Time,
+			Phase:             detectPhase(j),
+			AppliedIssueLabel: j.Annotations["agents.io/issue-label"],
 		})
 	}
 	return controller.State{

--- a/internal/controller/reconcile.go
+++ b/internal/controller/reconcile.go
@@ -23,11 +23,12 @@ type IssueState struct {
 
 // JobStatus describes a single Agent Job's current state.
 type JobStatus struct {
-	Name         string
-	IssueNumber  int
-	CreationTime time.Time
-	Phase        Phase
-	BlockedBy    []int // issue numbers from "Blocked by #N" lines
+	Name               string
+	IssueNumber        int
+	CreationTime       time.Time
+	Phase              Phase
+	BlockedBy          []int  // issue numbers from "Blocked by #N" lines
+	AppliedIssueLabel  string // value of agents.io/issue-label annotation; guards label-transition idempotency
 }
 
 // State is the input to Reconcile. It contains all observed Jobs, PRs, and configuration.
@@ -93,7 +94,7 @@ func Reconcile(state State) []Action {
 			suspended = append(suspended, j)
 		case PhaseRunning:
 			running++
-			if j.IssueNumber != 0 {
+			if j.IssueNumber != 0 && j.AppliedIssueLabel != "in-progress" {
 				actions = append(actions, UpdateLabel{
 					IssueNumber: j.IssueNumber,
 					Add:         "in-progress",
@@ -102,25 +103,36 @@ func Reconcile(state State) []Action {
 			}
 		case PhaseSucceeded:
 			if j.IssueNumber != 0 {
-				actions = append(actions, UpdateLabel{
-					IssueNumber: j.IssueNumber,
-					Add:         "waiting-for-review",
-					Remove:      "in-progress",
-				})
+				if j.AppliedIssueLabel != "waiting-for-review" {
+					actions = append(actions, UpdateLabel{
+						IssueNumber: j.IssueNumber,
+						Add:         "waiting-for-review",
+						Remove:      "in-progress",
+					})
+				}
 				if pr, ok := prByIssue[j.IssueNumber]; ok && !pr.Merged {
 					actions = append(actions, EnableAutoMerge{PRNumber: pr.PRNumber})
 				}
 			}
 		case PhaseFailed:
-			if j.IssueNumber != 0 {
+			if j.IssueNumber != 0 && j.AppliedIssueLabel != "failed" {
 				actions = append(actions, MarkFailed{IssueNumber: j.IssueNumber})
 			}
 		}
 	}
 
+	jobByIssue := make(map[int]JobStatus, len(state.Jobs))
+	for _, j := range state.Jobs {
+		if j.IssueNumber != 0 {
+			jobByIssue[j.IssueNumber] = j
+		}
+	}
+
 	for _, pr := range state.PRs {
 		if pr.Merged {
-			actions = append(actions, SetDone{IssueNumber: pr.IssueNumber})
+			if j, ok := jobByIssue[pr.IssueNumber]; !ok || j.AppliedIssueLabel != "done" {
+				actions = append(actions, SetDone{IssueNumber: pr.IssueNumber})
+			}
 		}
 	}
 

--- a/internal/controller/reconcile_test.go
+++ b/internal/controller/reconcile_test.go
@@ -381,6 +381,75 @@ func TestReconcile_MultipleBlockersMixed_StaysSuspended(t *testing.T) {
 	}
 }
 
+func TestReconcile_RunningJobLabelAlreadyApplied_NoUpdateLabel(t *testing.T) {
+	state := controller.State{
+		Jobs: []controller.JobStatus{
+			{Name: "agent-issue-42", IssueNumber: 42, CreationTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), Phase: controller.PhaseRunning, AppliedIssueLabel: "in-progress"},
+		},
+		MaxParallel: 3,
+	}
+
+	actions := controller.Reconcile(state)
+
+	for _, a := range actions {
+		if ul, ok := a.(controller.UpdateLabel); ok && ul.IssueNumber == 42 {
+			t.Errorf("unexpected UpdateLabel for issue 42 when in-progress already applied")
+		}
+	}
+}
+
+func TestReconcile_SucceededJobLabelAlreadyApplied_NoUpdateLabel(t *testing.T) {
+	state := controller.State{
+		Jobs: []controller.JobStatus{
+			{Name: "agent-issue-7", IssueNumber: 7, CreationTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), Phase: controller.PhaseSucceeded, AppliedIssueLabel: "waiting-for-review"},
+		},
+		MaxParallel: 3,
+	}
+
+	actions := controller.Reconcile(state)
+
+	for _, a := range actions {
+		if ul, ok := a.(controller.UpdateLabel); ok && ul.IssueNumber == 7 {
+			t.Errorf("unexpected UpdateLabel for issue 7 when waiting-for-review already applied")
+		}
+	}
+}
+
+func TestReconcile_FailedJobLabelAlreadyApplied_NoMarkFailed(t *testing.T) {
+	state := controller.State{
+		Jobs: []controller.JobStatus{
+			{Name: "agent-issue-5", IssueNumber: 5, CreationTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), Phase: controller.PhaseFailed, AppliedIssueLabel: "failed"},
+		},
+		MaxParallel: 3,
+	}
+
+	actions := controller.Reconcile(state)
+
+	if len(actions) != 0 {
+		t.Errorf("Reconcile() returned %d actions, want 0 (failed label already applied): %v", len(actions), actions)
+	}
+}
+
+func TestReconcile_MergedPRJobDoneAlreadyApplied_NoSetDone(t *testing.T) {
+	state := controller.State{
+		Jobs: []controller.JobStatus{
+			{Name: "agent-issue-7", IssueNumber: 7, CreationTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), Phase: controller.PhaseSucceeded, AppliedIssueLabel: "done"},
+		},
+		MaxParallel: 3,
+		PRs: []controller.PRStatus{
+			{IssueNumber: 7, PRNumber: 42, Merged: true},
+		},
+	}
+
+	actions := controller.Reconcile(state)
+
+	for _, a := range actions {
+		if _, ok := a.(controller.SetDone); ok {
+			t.Errorf("unexpected SetDone when done label already applied")
+		}
+	}
+}
+
 func TestReconcile_AllBlockersClosed_Eligible(t *testing.T) {
 	state := controller.State{
 		Jobs: []controller.JobStatus{

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -59,6 +59,20 @@ func (c *Client) UnsuspendJob(ctx context.Context, namespace, name string) error
 	return err
 }
 
+// SetJobAnnotation updates a single annotation on the named Job.
+func (c *Client) SetJobAnnotation(ctx context.Context, namespace, name, key, value string) error {
+	job, err := c.kube.BatchV1().Jobs(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	if job.Annotations == nil {
+		job.Annotations = make(map[string]string)
+	}
+	job.Annotations[key] = value
+	_, err = c.kube.BatchV1().Jobs(namespace).Update(ctx, job, metav1.UpdateOptions{})
+	return err
+}
+
 // ValidateSecret returns an error if the named Secret does not exist in namespace.
 func (c *Client) ValidateSecret(ctx context.Context, namespace, name string) error {
 	_, err := c.kube.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})

--- a/opencode-runner/Dockerfile
+++ b/opencode-runner/Dockerfile
@@ -18,7 +18,7 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
 
 # opencode (sst/opencode) — install latest release
 RUN curl -fsSL https://opencode.ai/install | bash
-ENV PATH="/root/.local/bin:${PATH}"
+ENV PATH="/root/.opencode/bin:${PATH}"
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
## Summary

- `Reconcile` emitted `UpdateLabel`/`MarkFailed`/`SetDone` every cycle because `State` contained no label info — no way to detect already-applied transitions
- Fix adds `AppliedIssueLabel string` to `JobStatus`, populated from k8s annotation `agents.io/issue-label`
- Each label-transition action is now guarded: skipped if the annotation shows it was already applied
- After executing a label action, controller writes the annotation back to the Job
- Same fix applied to all phases: `PhaseRunning` (in-progress), `PhaseSucceeded` (waiting-for-review), `PhaseFailed` (failed), and merged-PR `SetDone`
- 4 new idempotency tests added

## Test plan

- [ ] `go test ./...` passes
- [ ] Deploy to cluster, verify issue 29 label update fires once and stops looping

🤖 Generated with [Claude Code](https://claude.com/claude-code)